### PR TITLE
Read missing keypoint labels and allow training with them 

### DIFF
--- a/ultralytics/engine/trainer.py
+++ b/ultralytics/engine/trainer.py
@@ -375,6 +375,7 @@ class BaseTrainer:
             self.tloss = None
             self.optimizer.zero_grad()
             for i, batch in pbar:
+                assert "ignore_kpt" in batch
                 self.run_callbacks('on_train_batch_start')
                 # Warmup
                 ni = i + nb * epoch

--- a/ultralytics/utils/instance.py
+++ b/ultralytics/utils/instance.py
@@ -218,6 +218,11 @@ class Instances:
         self.keypoints = keypoints
         self.normalized = normalized
 
+        if keypoints is not None:
+            assert len(keypoints) == len(
+                bboxes
+            ), f"keypoints should have the same length as bboxes. {len(keypoints)} != {len(bboxes)}"
+
         if len(segments) > 0:
             # List[np.array(1000, 2)] * num_samples
             segments = resample_segments(segments)
@@ -298,7 +303,12 @@ class Instances:
             length as the number of instances.
         """
         segments = self.segments[index] if len(self.segments) else self.segments
-        keypoints = self.keypoints[index] if self.keypoints is not None else None
+        keypoints = None
+        if self.keypoints is not None:
+            assert len(self.keypoints) == len(
+                self.bboxes
+            ), f"keypoints should have the same length as bboxes. {len(self.keypoints)} != {len(self.bboxes)}"
+            keypoints = self.keypoints[index]
         bboxes = self.bboxes[index]
         bbox_format = self._bboxes.format
         return Instances(

--- a/ultralytics/utils/loss.py
+++ b/ultralytics/utils/loss.py
@@ -434,7 +434,7 @@ class v8PoseLoss(v8DetectionLoss):
             keypoints[..., 1] *= imgsz[0]
 
             loss[1], loss[2] = self.calculate_keypoints_loss(fg_mask, target_gt_idx, keypoints, batch_idx,
-                                                             stride_tensor, target_bboxes, pred_kpts)
+                                                             stride_tensor, target_bboxes, pred_kpts, batch['ignore_kpt'])
 
         loss[0] *= self.hyp.box  # box gain
         loss[1] *= self.hyp.pose  # pose gain
@@ -454,7 +454,7 @@ class v8PoseLoss(v8DetectionLoss):
         return y
 
     def calculate_keypoints_loss(self, masks, target_gt_idx, keypoints, batch_idx, stride_tensor, target_bboxes,
-                                 pred_kpts):
+                                 pred_kpts, ignore_kpt):
         """
         Calculate the keypoints loss for the model.
 
@@ -505,10 +505,19 @@ class v8PoseLoss(v8DetectionLoss):
         kpts_loss = 0
         kpts_obj_loss = 0
 
-        if masks.any():
-            gt_kpt = selected_keypoints[masks]
-            area = xyxy2xywh(target_bboxes[masks])[:, 2:].prod(1, keepdim=True)
-            pred_kpt = pred_kpts[masks]
+        mask_after_ignore = masks.clone()
+        for i in range(batch_size):
+            if ignore_kpt[i]:
+                # We should ignore the keypoints for this image
+                # We replace gt keypoints with pred keypoints so distance is 0. kpts_loss will be 0
+                selected_keypoints[i] = pred_kpts[i]
+                # We will set the mask to False for all the keypoints of this image
+                mask_after_ignore[i] = False
+
+        if mask_after_ignore.any():
+            gt_kpt = selected_keypoints[mask_after_ignore]
+            area = xyxy2xywh(target_bboxes[mask_after_ignore])[:, 2:].prod(1, keepdim=True)
+            pred_kpt = pred_kpts[mask_after_ignore]
             kpt_mask = gt_kpt[..., 2] != 0 if gt_kpt.shape[-1] == 3 else torch.full_like(gt_kpt[..., 0], True)
             kpts_loss = self.keypoint_loss(pred_kpt, gt_kpt, kpt_mask, area)  # pose loss
 


### PR DESCRIPTION
This MR handles very specific case.
What if we want to train a model which can predict bounding boxes with keypoints but not all of our data is labeled with keypoints.
This uses hybrid training data. 
* If `labels.txt` file has just the bounding box data that read that, add fake keypoints with [0,0,0] and add another flag which is `ignore_keypoint`
* With this, at the time of computing loss, we can mask out all the keypoints for that image. This way keypoint loss will be used only for the image which has that label information. 