### PR TITLE
Fixed loading weights from checkpoint

### DIFF
--- a/training_utils/simple_training.py
+++ b/training_utils/simple_training.py
@@ -20,17 +20,12 @@ if __name__ == "__main__":
     parser.add_argument("-l", "--load", type=str, default=None, help="Path to the model weights to load. Load the pretrained model")
 
     args = parser.parse_args()
-    model = YOLO(GetModelYaml(training_task))  # Initialize model
+    if args.load is not None:
+        model = YOLO(args.load)  # Initialize model
+    else:
+        model = YOLO(GetModelYaml(training_task))  # Initialize model
 
     PrepareDataset(coco_classes_file, dataset_yaml_path, training_task)
-    model = YOLO(GetModelYaml(training_task))  # Initialize model
-
-    if args.load is not None:
-        if os.path.exists(args.load):
-            model.load(args.load)
-        else:
-            print(f"[ERROR] : Model {args.load} does not exists")
-            exit(1)
 
     model.train(
         task=training_task,


### PR DESCRIPTION
At head, the weights are loaded from the coco checkpoint, which changes the dimensions of some layers, then the model is loaded again from the intended checkpoint, which changes back the dimensions of the layers. The result is that any layer that doesn't match the dimensions of the coco checkpoint cannot be loaded from a previous checkpoint and is re-initialized instead.

With this change, if a checkpoint is provided, the model is loaded directly from it.

Test Plan:
- python simple_training.py --load my_checkpoint.pt
- Before the change, not all layers were loaded ("Transferred 355/397 items from pretrained weights")
- After the change, all layers are loaded.