### PR TITLE
Fix model loading

### DIFF
--- a/training_utils/simple_training.py
+++ b/training_utils/simple_training.py
@@ -20,21 +20,24 @@ if __name__ == "__main__":
     parser.add_argument("-l", "--load", type=str, default=None, help="Path to the model weights to load. Load the pretrained model")
 
     args = parser.parse_args()
-    model = YOLO(GetModelYaml(training_task))  # Initialize model
 
     PrepareDataset(coco_classes_file, dataset_yaml_path, training_task)
-    model = YOLO(GetModelYaml(training_task))  # Initialize model
 
     if args.load is not None:
         if os.path.exists(args.load):
-            model.load(args.load)
+            model = YOLO(args.load)
         else:
             print(f"[ERROR] : Model {args.load} does not exists")
             exit(1)
+    else:
+        model = YOLO(GetModelYaml(training_task))  # Initialize model
 
     model.train(
         task=training_task,
         data="verdant.yaml",
+        optimizer='SGD',
+        lr0=0.01,
+        lrf=0.01,
         epochs=300,
         flipud=0.5,
         fliplr=0.5,

--- a/ultralytics/engine/trainer.py
+++ b/ultralytics/engine/trainer.py
@@ -289,7 +289,9 @@ class BaseTrainer:
         self.amp = bool(self.amp)  # as boolean
         self.scaler = amp.GradScaler(enabled=self.amp)
         if world_size > 1:
-            self.model = DDP(self.model, device_ids=[RANK])
+            # TODO(thibaux): find_unused_parameters is necessary to prevent crashes, but it slows down training.
+            # It might be due to some batches not containing any keypoint labels.
+            self.model = DDP(self.model, device_ids=[RANK], find_unused_parameters=True)
 
         # Check imgsz
         gs = max(int(self.model.stride.max() if hasattr(self.model, 'stride') else 32), 32)  # grid size (max stride)


### PR DESCRIPTION
Through trial and error, I found that this is the more correct way to load a model, either from a standard architecture or from an existing model.

This PR also adds the "find_unused_parameters", without which training sometimes crashes, probably because some batches, randomly, have no keypoint labels, which causes the gradient to receive no contribution and the trainer to be surprised. Using this flag comes at a speed cost.

Tested:
- python simple_training.py