### PR TITLE
[VRS-833] Make triplet loss an option in ultralytics library

### DIFF
--- a/training_utils/simple_training.py
+++ b/training_utils/simple_training.py
@@ -38,7 +38,7 @@ if __name__ == "__main__":
         optimizer='SGD',
         lr0=0.01,
         lrf=0.01,
-        epochs=300,
+        epochs=500,
         flipud=0.5,
         fliplr=0.5,
         scale=0.2,
@@ -48,6 +48,7 @@ if __name__ == "__main__":
         batch=128,
         name=experiment_name,
         device=[0, 1, 2, 3, 4, 5, 6, 7],
+        patience=300,
     )
 
     latest_weights_dir = GetLatestWeightsDir()

--- a/training_utils/simple_training.py
+++ b/training_utils/simple_training.py
@@ -38,7 +38,7 @@ if __name__ == "__main__":
         optimizer='SGD',
         lr0=0.01,
         lrf=0.01,
-        epochs=500,
+        epochs=300,
         flipud=0.5,
         fliplr=0.5,
         scale=0.2,
@@ -48,7 +48,7 @@ if __name__ == "__main__":
         batch=128,
         name=experiment_name,
         device=[0, 1, 2, 3, 4, 5, 6, 7],
-        patience=300,
+        patience=50,
     )
 
     latest_weights_dir = GetLatestWeightsDir()

--- a/training_utils/training_utils.py
+++ b/training_utils/training_utils.py
@@ -26,7 +26,7 @@ def PrepareDataset(coco_classes_file, dataset_yaml, training_task):
         f.write("names:\n")
         for i in range(len(classes)):
             f.write(f"  {i}: {classes[i]}\n")
-        if training_task == "pose":
+        if training_task == "pose" or training_task == "pose-contrastive":
             f.write("\nkpt_shape: [1, 3]\n")
     return
 
@@ -36,6 +36,8 @@ def GetModelYaml(task):
         return "yolov8n.yaml"
     elif task == "pose":
         return "yolov8n-pose.yaml"
+    elif task == "pose-contrastive":
+        return "yolov8n-pose-contrastive.yaml"
     print(f"Unknown task {task}")
     return None
 

--- a/ultralytics/cfg/__init__.py
+++ b/ultralytics/cfg/__init__.py
@@ -13,18 +13,20 @@ from ultralytics.utils import (ASSETS, DEFAULT_CFG, DEFAULT_CFG_DICT, DEFAULT_CF
 
 # Define valid tasks and modes
 MODES = 'train', 'val', 'predict', 'export', 'track', 'benchmark'
-TASKS = 'detect', 'segment', 'classify', 'pose'
-TASK2DATA = {'detect': 'coco8.yaml', 'segment': 'coco8-seg.yaml', 'classify': 'imagenet10', 'pose': 'coco8-pose.yaml'}
+TASKS = 'detect', 'segment', 'classify', 'pose', 'pose-contrastive'
+TASK2DATA = {'detect': 'coco8.yaml', 'segment': 'coco8-seg.yaml', 'classify': 'imagenet10', 'pose': 'coco8-pose.yaml', 'pose-contrastive': 'coco8-pose.yaml'}
 TASK2MODEL = {
     'detect': 'yolov8n.pt',
     'segment': 'yolov8n-seg.pt',
     'classify': 'yolov8n-cls.pt',
-    'pose': 'yolov8n-pose.pt'}
+    'pose': 'yolov8n-pose.pt',
+    'pose-contrastive': 'yolov8n-pose-contrastive.pt'}
 TASK2METRIC = {
     'detect': 'metrics/mAP50-95(B)',
     'segment': 'metrics/mAP50-95(M)',
     'classify': 'metrics/accuracy_top1',
-    'pose': 'metrics/mAP50-95(P)'}
+    'pose': 'metrics/mAP50-95(P)',
+    'pose-contrastive': 'metrics/mAP50-95(P)'}
 
 CLI_HELP_MSG = \
     f"""

--- a/ultralytics/cfg/default.yaml
+++ b/ultralytics/cfg/default.yaml
@@ -8,7 +8,7 @@ mode: train  # (str) YOLO mode, i.e. train, val, predict, export, track, benchma
 model:  # (str, optional) path to model file, i.e. yolov8n.pt, yolov8n.yaml
 data:  # (str, optional) path to data file, i.e. coco128.yaml
 epochs: 100  # (int) number of epochs to train for
-patience: 50  # (int) epochs to wait for no observable improvement for early stopping of training
+patience: 300  # (int) epochs to wait for no observable improvement for early stopping of training
 batch: 16  # (int) number of images per batch (-1 for AutoBatch)
 imgsz: 640  # (int | list) input images size as int for train and val modes, or list[w,h] for predict and export modes
 save: True  # (bool) save train checkpoints and predict results

--- a/ultralytics/cfg/default.yaml
+++ b/ultralytics/cfg/default.yaml
@@ -8,7 +8,7 @@ mode: train  # (str) YOLO mode, i.e. train, val, predict, export, track, benchma
 model:  # (str, optional) path to model file, i.e. yolov8n.pt, yolov8n.yaml
 data:  # (str, optional) path to data file, i.e. coco128.yaml
 epochs: 100  # (int) number of epochs to train for
-patience: 300  # (int) epochs to wait for no observable improvement for early stopping of training
+patience: 50  # (int) epochs to wait for no observable improvement for early stopping of training
 batch: 16  # (int) number of images per batch (-1 for AutoBatch)
 imgsz: 640  # (int | list) input images size as int for train and val modes, or list[w,h] for predict and export modes
 save: True  # (bool) save train checkpoints and predict results

--- a/ultralytics/cfg/default.yaml
+++ b/ultralytics/cfg/default.yaml
@@ -1,7 +1,7 @@
 # Ultralytics YOLO 🚀, AGPL-3.0 license
 # Default training settings and hyperparameters for medium-augmentation COCO training
 
-task: detect  # (str) YOLO task, i.e. detect, segment, classify, pose
+task: detect  # (str) YOLO task, i.e. detect, segment, classify, pose, pose-contrastive
 mode: train  # (str) YOLO mode, i.e. train, val, predict, export, track, benchmark
 
 # Train settings -------------------------------------------------------------------------------------------------------

--- a/ultralytics/cfg/models/v8/yolov8-pose-contrastive.yaml
+++ b/ultralytics/cfg/models/v8/yolov8-pose-contrastive.yaml
@@ -1,0 +1,47 @@
+# Ultralytics YOLO 🚀, AGPL-3.0 license
+# YOLOv8-pose keypoints/pose estimation model. For Usage examples see https://docs.ultralytics.com/tasks/pose
+
+# Parameters
+nc: 1  # number of classes
+kpt_shape: [17, 3]  # number of keypoints, number of dims (2 for x,y or 3 for x,y,visible)
+scales: # model compound scaling constants, i.e. 'model=yolov8n-pose-contrastive.yaml' will call yolov8-pose-contrastive.yaml with scale 'n'
+  # [depth, width, max_channels]
+  n: [0.33, 0.25, 1024]
+  s: [0.33, 0.50, 1024]
+  m: [0.67, 0.75, 768]
+  l: [1.00, 1.00, 512]
+  x: [1.00, 1.25, 512]
+
+# YOLOv8.0n backbone
+backbone:
+  # [from, repeats, module, args]
+  - [-1, 1, Conv, [64, 3, 2]]  # 0-P1/2
+  - [-1, 1, Conv, [128, 3, 2]]  # 1-P2/4
+  - [-1, 3, C2f, [128, True]]
+  - [-1, 1, Conv, [256, 3, 2]]  # 3-P3/8
+  - [-1, 6, C2f, [256, True]]
+  - [-1, 1, Conv, [512, 3, 2]]  # 5-P4/16
+  - [-1, 6, C2f, [512, True]]
+  - [-1, 1, Conv, [1024, 3, 2]]  # 7-P5/32
+  - [-1, 3, C2f, [1024, True]]
+  - [-1, 1, SPPF, [1024, 5]]  # 9
+
+# YOLOv8.0n head
+head:
+  - [-1, 1, nn.Upsample, [None, 2, 'nearest']]
+  - [[-1, 6], 1, Concat, [1]]  # cat backbone P4
+  - [-1, 3, C2f, [512]]  # 12
+
+  - [-1, 1, nn.Upsample, [None, 2, 'nearest']]
+  - [[-1, 4], 1, Concat, [1]]  # cat backbone P3
+  - [-1, 3, C2f, [256]]  # 15 (P3/8-small)
+
+  - [-1, 1, Conv, [256, 3, 2]]
+  - [[-1, 12], 1, Concat, [1]]  # cat head P4
+  - [-1, 3, C2f, [512]]  # 18 (P4/16-medium)
+
+  - [-1, 1, Conv, [512, 3, 2]]
+  - [[-1, 9], 1, Concat, [1]]  # cat head P5
+  - [-1, 3, C2f, [1024]]  # 21 (P5/32-large)
+
+  - [[15, 18, 21], 1, PoseContrastive, [nc, kpt_shape]]  # Pose(P3, P4, P5)

--- a/ultralytics/models/yolo/model.py
+++ b/ultralytics/models/yolo/model.py
@@ -2,7 +2,7 @@
 
 from ultralytics.engine.model import Model
 from ultralytics.models import yolo  # noqa
-from ultralytics.nn.tasks import ClassificationModel, DetectionModel, PoseModel, SegmentationModel
+from ultralytics.nn.tasks import ClassificationModel, DetectionModel, PoseModel, PoseContrastiveModel, SegmentationModel
 
 
 class YOLO(Model):
@@ -30,5 +30,10 @@ class YOLO(Model):
             'pose': {
                 'model': PoseModel,
                 'trainer': yolo.pose.PoseTrainer,
+                'validator': yolo.pose.PoseValidator,
+                'predictor': yolo.pose.PosePredictor, }, 
+            'pose-contrastive': {
+                'model': PoseContrastiveModel,
+                'trainer': yolo.pose.PoseContrastiveTrainer,
                 'validator': yolo.pose.PoseValidator,
                 'predictor': yolo.pose.PosePredictor, }, }

--- a/ultralytics/models/yolo/pose/__init__.py
+++ b/ultralytics/models/yolo/pose/__init__.py
@@ -1,7 +1,7 @@
 # Ultralytics YOLO 🚀, AGPL-3.0 license
 
 from .predict import PosePredictor
-from .train import PoseTrainer
+from .train import PoseTrainer, PoseContrastiveTrainer
 from .val import PoseValidator
 
-__all__ = 'PoseTrainer', 'PoseValidator', 'PosePredictor'
+__all__ = 'PoseTrainer', 'PoseContrastiveTrainer', 'PoseValidator', 'PosePredictor'

--- a/ultralytics/models/yolo/pose/train.py
+++ b/ultralytics/models/yolo/pose/train.py
@@ -48,7 +48,7 @@ class PoseTrainer(yolo.detect.DetectionTrainer):
 
     def get_validator(self):
         """Returns an instance of the PoseValidator class for validation."""
-        self.loss_names = 'box_loss', 'pose_loss', 'kobj_loss', 'cls_loss', 'dfl_loss'
+        self.loss_names = 'box_loss', 'pose_loss', 'kobj_loss', 'cls_loss', 'dfl_loss', 'triplet_loss'
         return yolo.pose.PoseValidator(self.test_loader, save_dir=self.save_dir, args=copy(self.args))
 
     def plot_training_samples(self, batch, ni):

--- a/ultralytics/models/yolo/pose/train.py
+++ b/ultralytics/models/yolo/pose/train.py
@@ -79,15 +79,15 @@ class PoseContrastiveTrainer(PoseTrainer):
 
     Example:
         ```python
-        from ultralytics.models.yolo.pose import PoseTrainer
+        from ultralytics.models.yolo.pose import PoseContrastiveTrainer
 
-        args = dict(model='yolov8n-pose.pt', data='coco8-pose.yaml', epochs=3)
-        trainer = PoseTrainer(overrides=args)
+        args = dict(model='yolov8n-pose-contrastive.pt', data='coco8-pose.yaml', epochs=3)
+        trainer = PoseContrastiveTrainer(overrides=args)
         trainer.train()
         ```
     """
     def __init__(self, cfg=DEFAULT_CFG, overrides=None, _callbacks=None):
-        """Initialize a PoseTrainer object with specified configurations and overrides."""
+        """Initialize a PoseContrastiveTrainer object with specified configurations and overrides."""
         if overrides is None:
             overrides = {}
         overrides['task'] = 'pose_contrastive'

--- a/ultralytics/models/yolo/pose/train.py
+++ b/ultralytics/models/yolo/pose/train.py
@@ -48,7 +48,7 @@ class PoseTrainer(yolo.detect.DetectionTrainer):
 
     def get_validator(self):
         """Returns an instance of the PoseValidator class for validation."""
-        self.loss_names = 'box_loss', 'pose_loss', 'kobj_loss', 'cls_loss', 'dfl_loss', 'triplet_loss'
+        self.loss_names = 'box_loss', 'pose_loss', 'kobj_loss', 'cls_loss', 'dfl_loss', 'triplet_loss', 'avg_logits'
         return yolo.pose.PoseValidator(self.test_loader, save_dir=self.save_dir, args=copy(self.args))
 
     def plot_training_samples(self, batch, ni):

--- a/ultralytics/models/yolo/pose/train.py
+++ b/ultralytics/models/yolo/pose/train.py
@@ -3,7 +3,7 @@
 from copy import copy
 
 from ultralytics.models import yolo
-from ultralytics.nn.tasks import PoseModel
+from ultralytics.nn.tasks import PoseModel, PoseContrastiveModel
 from ultralytics.utils import DEFAULT_CFG, LOGGER
 from ultralytics.utils.plotting import plot_images, plot_results
 
@@ -48,7 +48,7 @@ class PoseTrainer(yolo.detect.DetectionTrainer):
 
     def get_validator(self):
         """Returns an instance of the PoseValidator class for validation."""
-        self.loss_names = 'box_loss', 'pose_loss', 'kobj_loss', 'cls_loss', 'dfl_loss', 'triplet_loss', 'avg_logits'
+        self.loss_names = 'box_loss', 'pose_loss', 'kobj_loss', 'cls_loss', 'dfl_loss', 'trpl_loss', 'avg_logits'
         return yolo.pose.PoseValidator(self.test_loader, save_dir=self.save_dir, args=copy(self.args))
 
     def plot_training_samples(self, batch, ni):
@@ -71,3 +71,36 @@ class PoseTrainer(yolo.detect.DetectionTrainer):
     def plot_metrics(self):
         """Plots training/val metrics."""
         plot_results(file=self.csv, pose=True, on_plot=self.on_plot)  # save results.png
+
+
+class PoseContrastiveTrainer(PoseTrainer):
+    """
+    A class extending the DetectionTrainer class for training based on a pose model.
+
+    Example:
+        ```python
+        from ultralytics.models.yolo.pose import PoseTrainer
+
+        args = dict(model='yolov8n-pose.pt', data='coco8-pose.yaml', epochs=3)
+        trainer = PoseTrainer(overrides=args)
+        trainer.train()
+        ```
+    """
+    def __init__(self, cfg=DEFAULT_CFG, overrides=None, _callbacks=None):
+        """Initialize a PoseTrainer object with specified configurations and overrides."""
+        if overrides is None:
+            overrides = {}
+        overrides['task'] = 'pose_contrastive'
+        super().__init__(cfg, overrides, _callbacks)
+
+        if isinstance(self.args.device, str) and self.args.device.lower() == 'mps':
+            LOGGER.warning("WARNING ⚠️ Apple MPS known Pose bug. Recommend 'device=cpu' for Pose models. "
+                           'See https://github.com/ultralytics/ultralytics/issues/4031.')
+            
+    def get_model(self, cfg=None, weights=None, verbose=True):
+        """Get pose estimation model with specified configuration and weights."""
+        model = PoseContrastiveModel(cfg, ch=3, nc=self.data['nc'], data_kpt_shape=self.data['kpt_shape'], verbose=verbose)
+        if weights:
+            model.load(weights)
+
+        return model

--- a/ultralytics/nn/modules/__init__.py
+++ b/ultralytics/nn/modules/__init__.py
@@ -21,13 +21,13 @@ from .block import (C1, C2, C3, C3TR, DFL, SPP, SPPF, Bottleneck, BottleneckCSP,
                     HGBlock, HGStem, Proto, RepC3)
 from .conv import (CBAM, ChannelAttention, Concat, Conv, Conv2, ConvTranspose, DWConv, DWConvTranspose2d, Focus,
                    GhostConv, LightConv, RepConv, SpatialAttention)
-from .head import Classify, Detect, Pose, RTDETRDecoder, Segment
+from .head import Classify, Detect, DetectContrastive, Pose, PoseContrastive, RTDETRDecoder, Segment
 from .transformer import (AIFI, MLP, DeformableTransformerDecoder, DeformableTransformerDecoderLayer, LayerNorm2d,
                           MLPBlock, MSDeformAttn, TransformerBlock, TransformerEncoderLayer, TransformerLayer)
 
 __all__ = ('Conv', 'Conv2', 'LightConv', 'RepConv', 'DWConv', 'DWConvTranspose2d', 'ConvTranspose', 'Focus',
            'GhostConv', 'ChannelAttention', 'SpatialAttention', 'CBAM', 'Concat', 'TransformerLayer',
            'TransformerBlock', 'MLPBlock', 'LayerNorm2d', 'DFL', 'HGBlock', 'HGStem', 'SPP', 'SPPF', 'C1', 'C2', 'C3',
-           'C2f', 'C3x', 'C3TR', 'C3Ghost', 'GhostBottleneck', 'Bottleneck', 'BottleneckCSP', 'Proto', 'Detect',
-           'Segment', 'Pose', 'Classify', 'TransformerEncoderLayer', 'RepC3', 'RTDETRDecoder', 'AIFI',
+           'C2f', 'C3x', 'C3TR', 'C3Ghost', 'GhostBottleneck', 'Bottleneck', 'BottleneckCSP', 'Proto', 'Detect', 'DetectContrastive',
+           'Segment', 'Pose', 'PoseContrastive', 'Classify', 'TransformerEncoderLayer', 'RepC3', 'RTDETRDecoder', 'AIFI',
            'DeformableTransformerDecoder', 'DeformableTransformerDecoderLayer', 'MSDeformAttn', 'MLP')

--- a/ultralytics/nn/modules/head.py
+++ b/ultralytics/nn/modules/head.py
@@ -55,8 +55,8 @@ class Detect(nn.Module):
         for i in range(self.nl):  # e.g., per detection scale (small, medium, or large)
             bboxes = self.cv2[i](x[i])  # (B, 4 * reg_max, H, W)
             embeddings = self.embedding_layers[i](x[i])  # (B, n_features, H, W)
-            predictions = self.cls_preds[i](embeddings)  # (B, nc, H, W)
-            x[i] = torch.cat((bboxes, predictions, embeddings), 1)  # (B, 4 * reg_max + nc + n_features, H, W)
+            cls_predidctions = self.cls_preds[i](embeddings)  # (B, nc, H, W)
+            x[i] = torch.cat((bboxes, cls_predidctions, embeddings), 1)  # (B, 4 * reg_max + nc + n_features, H, W)
             
         if self.training:
             return x
@@ -64,16 +64,14 @@ class Detect(nn.Module):
             self.anchors, self.strides = (x.transpose(0, 1) for x in make_anchors(x, self.stride, 0.5))
             self.shape = shape
 
-        # for inference, we don't need embeddings
-        for i in range(self.nl):
-            x[i] = (self.cv2[i][i], self.cv3[i](x[i]))  # bbox, cls
-
         x_cat = torch.cat([xi.view(shape[0], self.no, -1) for xi in x], 2)
         if self.export and self.format in ('saved_model', 'pb', 'tflite', 'edgetpu', 'tfjs'):  # avoid TF FlexSplitV ops
             box = x_cat[:, :self.reg_max * 4]
-            cls = x_cat[:, self.reg_max * 4:]
+            cls = x_cat[:, self.reg_max * 4: self.reg_max * 4 + self.nc]
+            emb = x_cat[:, self.reg_max * 4 + self.nc:]
         else:
-            box, cls = x_cat.split((self.reg_max * 4, self.nc), 1)
+            # box, cls = x_cat.split((self.reg_max * 4, self.nc), 1)
+            box, cls, emb = x_cat.split((self.reg_max * 4, self.nc, (self.no - self.reg_max * 4 - self.nc)), 1)
         dbox = dist2bbox(self.dfl(box), self.anchors.unsqueeze(0), xywh=True, dim=1) * self.strides
 
         if self.export and self.format in ('tflite', 'edgetpu'):

--- a/ultralytics/nn/modules/head.py
+++ b/ultralytics/nn/modules/head.py
@@ -148,7 +148,6 @@ class DetectContrastive(nn.Module):
         if self.export and self.format in ('saved_model', 'pb', 'tflite', 'edgetpu', 'tfjs'):  # avoid TF FlexSplitV ops
             box = x_cat[:, :self.reg_max * 4]
             cls = x_cat[:, self.reg_max * 4: self.reg_max * 4 + self.nc]
-            _ = x_cat[:, self.reg_max * 4 + self.nc:]  # embeddings for contrastive learning
         else:
             box, cls, _ = x_cat.split((self.reg_max * 4, self.nc, (self.no - self.reg_max * 4 - self.nc)), 1)  # box, cls, embeddings
         dbox = dist2bbox(self.dfl(box), self.anchors.unsqueeze(0), xywh=True, dim=1) * self.strides

--- a/ultralytics/nn/modules/head.py
+++ b/ultralytics/nn/modules/head.py
@@ -57,11 +57,11 @@ class Detect(nn.Module):
 
     def forward(self, x):
         """Concatenates and returns predicted bounding boxes and class probabilities."""
-        shared_conv1_weight = self.cls_preds[0].weight
-        shared_conv2_weight = self.cls_preds[1].weight
-        shared_conv3_weight = self.cls_preds[2].weight
-        print(f"conv1==conv2: {torch.equal(shared_conv1_weight, shared_conv2_weight)}")
-        print(f"conv2==conv3: {torch.equal(shared_conv2_weight, shared_conv3_weight)}")
+        # shared_conv1_weight = self.cls_preds[0].weight
+        # shared_conv2_weight = self.cls_preds[1].weight
+        # shared_conv3_weight = self.cls_preds[2].weight
+        # print(f"conv1==conv2: {torch.equal(shared_conv1_weight, shared_conv2_weight)}")
+        # print(f"conv2==conv3: {torch.equal(shared_conv2_weight, shared_conv3_weight)}")
         
         shape = x[0].shape  # BCHW
         for i in range(self.nl):  # e.g., per detection scale (small, medium, or large)

--- a/ultralytics/nn/tasks.py
+++ b/ultralytics/nn/tasks.py
@@ -71,7 +71,7 @@ class BaseModel(nn.Module):
             (torch.Tensor): The last output of the model.
         """
         y, dt = [], []  # outputs
-        for m in self.model:  # model here could mean a list of layers
+        for m in self.model:  # a list of layers in sequence (torch.nn.modules.container.Sequential)
             if m.f != -1:  # if not from previous layer
                 x = y[m.f] if isinstance(m.f, int) else [x if j == -1 else y[j] for j in m.f]  # from earlier layers
             if profile:
@@ -80,7 +80,7 @@ class BaseModel(nn.Module):
             y.append(x if m.i in self.save else None)  # save output
             if visualize:
                 feature_visualization(x, m.type, m.i, save_dir=visualize)
-        return x
+        return x  # tuple(x[0],x[1]) where x[0] contains (B,C,H,W) for small, med, large & x[1] contains (B,?,n_total_anchors)
 
     def _predict_augment(self, x):
         """Perform augmentations on input image x and return augmented inference."""

--- a/ultralytics/nn/tasks.py
+++ b/ultralytics/nn/tasks.py
@@ -8,12 +8,12 @@ import torch
 import torch.nn as nn
 
 from ultralytics.nn.modules import (AIFI, C1, C2, C3, C3TR, SPP, SPPF, Bottleneck, BottleneckCSP, C2f, C3Ghost, C3x,
-                                    Classify, Concat, Conv, Conv2, ConvTranspose, Detect, DWConv, DWConvTranspose2d,
-                                    Focus, GhostBottleneck, GhostConv, HGBlock, HGStem, Pose, RepC3, RepConv,
+                                    Classify, Concat, Conv, Conv2, ConvTranspose, Detect, DetectContrastive, DWConv, DWConvTranspose2d,
+                                    Focus, GhostBottleneck, GhostConv, HGBlock, HGStem, Pose, PoseContrastive, RepC3, RepConv,
                                     RTDETRDecoder, Segment)
 from ultralytics.utils import DEFAULT_CFG_DICT, DEFAULT_CFG_KEYS, LOGGER, colorstr, emojis, yaml_load
 from ultralytics.utils.checks import check_requirements, check_suffix, check_yaml
-from ultralytics.utils.loss import v8ClassificationLoss, v8DetectionLoss, v8PoseLoss, v8SegmentationLoss
+from ultralytics.utils.loss import v8ClassificationLoss, v8DetectionLoss, v8PoseLoss, v8PoseContrastiveLoss, v8SegmentationLoss
 from ultralytics.utils.plotting import feature_visualization
 from ultralytics.utils.torch_utils import (fuse_conv_and_bn, fuse_deconv_and_bn, initialize_weights, intersect_dicts,
                                            make_divisible, model_info, scale_img, time_sync)
@@ -176,7 +176,7 @@ class BaseModel(nn.Module):
         """
         self = super()._apply(fn)
         m = self.model[-1]  # Detect()
-        if isinstance(m, (Detect, Segment)):
+        if isinstance(m, (Detect, DetectContrastive, Segment)):
             m.stride = fn(m.stride)
             m.anchors = fn(m.anchors)
             m.strides = fn(m.strides)
@@ -235,10 +235,10 @@ class DetectionModel(BaseModel):
 
         # Build strides
         m = self.model[-1]  # Detect()
-        if isinstance(m, (Detect, Segment, Pose)):
+        if isinstance(m, (Detect, DetectContrastive, Segment, Pose, PoseContrastive)):
             s = 256  # 2x min stride
             m.inplace = self.inplace
-            forward = lambda x: self.forward(x)[0] if isinstance(m, (Segment, Pose)) else self.forward(x)
+            forward = lambda x: self.forward(x)[0] if isinstance(m, (Segment, Pose, PoseContrastive)) else self.forward(x)
             m.stride = torch.tensor([s / x.shape[-2] for x in forward(torch.zeros(1, ch, s, s))])  # forward
             self.stride = m.stride
             m.bias_init()  # only run once
@@ -319,6 +319,17 @@ class PoseModel(DetectionModel):
     def init_criterion(self):
         """Initialize the loss criterion for the PoseModel."""
         return v8PoseLoss(self)
+    
+
+class PoseContrastiveModel(PoseModel):
+    """YOLOv8 pose model."""
+    def __init__(self, cfg='yolov8n-pose-contrastive.yaml', ch=3, nc=None, data_kpt_shape=(None, None), verbose=True):
+        """Initialize YOLOv8 PoseContrastiveModel."""
+        super().__init__(cfg=cfg, ch=ch, nc=nc, data_kpt_shape=data_kpt_shape, verbose=verbose)
+
+    def init_criterion(self):
+        """Initialize the loss criterion for the PoseModel."""
+        return v8PoseContrastiveLoss(self)
 
 
 class ClassificationModel(BaseModel):
@@ -605,7 +616,7 @@ def attempt_load_weights(weights, device=None, inplace=True, fuse=False):
     # Module updates
     for m in ensemble.modules():
         t = type(m)
-        if t in (nn.Hardswish, nn.LeakyReLU, nn.ReLU, nn.ReLU6, nn.SiLU, Detect, Segment):
+        if t in (nn.Hardswish, nn.LeakyReLU, nn.ReLU, nn.ReLU6, nn.SiLU, Detect, DetectContrastive, Segment):
             m.inplace = inplace
         elif t is nn.Upsample and not hasattr(m, 'recompute_scale_factor'):
             m.recompute_scale_factor = None  # torch 1.11.0 compatibility
@@ -641,7 +652,7 @@ def attempt_load_one_weight(weight, device=None, inplace=True, fuse=False):
     # Module updates
     for m in model.modules():
         t = type(m)
-        if t in (nn.Hardswish, nn.LeakyReLU, nn.ReLU, nn.ReLU6, nn.SiLU, Detect, Segment):
+        if t in (nn.Hardswish, nn.LeakyReLU, nn.ReLU, nn.ReLU6, nn.SiLU, Detect, DetectContrastive, Segment):
             m.inplace = inplace
         elif t is nn.Upsample and not hasattr(m, 'recompute_scale_factor'):
             m.recompute_scale_factor = None  # torch 1.11.0 compatibility
@@ -705,7 +716,7 @@ def parse_model(d, ch, verbose=True):  # model_dict, input_channels(3)
             args = [ch[f]]
         elif m is Concat:
             c2 = sum(ch[x] for x in f)
-        elif m in (Detect, Segment, Pose):
+        elif m in (Detect, DetectContrastive, Segment, Pose, PoseContrastive):
             args.append([ch[x] for x in f])
             if m is Segment:
                 args[2] = make_divisible(min(args[2], max_channels) * width, 8)
@@ -789,6 +800,8 @@ def guess_model_task(model):
             return 'segment'
         if m == 'pose':
             return 'pose'
+        if m == 'posecontrastive':
+            return 'pose-contrastive'
 
     # Guess from model cfg
     if isinstance(model, dict):

--- a/ultralytics/nn/tasks.py
+++ b/ultralytics/nn/tasks.py
@@ -783,7 +783,7 @@ def guess_model_task(model):
         model (nn.Module | dict): PyTorch model or model configuration in YAML format.
 
     Returns:
-        (str): Task of the model ('detect', 'segment', 'classify', 'pose').
+        (str): Task of the model ('detect', 'segment', 'classify', 'pose', 'pose-contrastive).
 
     Raises:
         SyntaxError: If the task of the model could not be determined.

--- a/ultralytics/nn/tasks.py
+++ b/ultralytics/nn/tasks.py
@@ -71,7 +71,7 @@ class BaseModel(nn.Module):
             (torch.Tensor): The last output of the model.
         """
         y, dt = [], []  # outputs
-        for m in self.model:
+        for m in self.model:  # model here could mean a list of layers
             if m.f != -1:  # if not from previous layer
                 x = y[m.f] if isinstance(m.f, int) else [x if j == -1 else y[j] for j in m.f]  # from earlier layers
             if profile:

--- a/ultralytics/utils/loss.py
+++ b/ultralytics/utils/loss.py
@@ -484,7 +484,6 @@ class v8PoseLoss(v8DetectionLoss):
                 return selected_indices
         
             query_indices = select_rand_idx_per_class(targets, query_class_indices)  # query sample indices (n_samples,)
-            # pos_indices = query_indices[torch.randperm(len(query_indices))]  # positive sample indices (n_samples,)
             pos_indices = select_rand_idx_per_class(targets, query_class_indices)  # positive sample indices (n_samples,)
             neg_indices = select_rand_idx_per_class(targets, neg_class_indices)  # negative sample indices (n_samples,)
 

--- a/ultralytics/utils/loss.py
+++ b/ultralytics/utils/loss.py
@@ -446,9 +446,6 @@ class v8PoseLoss(v8DetectionLoss):
         loss[2] *= self.hyp.kobj  # kobj gain
         loss[3] *= self.hyp.cls  # cls gain
         loss[4] *= self.hyp.dfl  # dfl gain
-
-        #TODO: conduct experiment with sub-features per embedding
-        embeddings = embeddings[:,:,embeddings.shape[2]//2:]  # last 32 embeddings
         
         # custom triplet loss for classification
         # target_labels (B, n_anchors)

--- a/ultralytics/utils/loss.py
+++ b/ultralytics/utils/loss.py
@@ -509,6 +509,7 @@ class v8PoseLoss(v8DetectionLoss):
             triplet_loss += F.binary_cross_entropy_with_logits(logits, y, reduction='sum')
 
         triplet_loss /= batch_size
+        triplet_loss = 0  # disable triplet loss
         loss[5] = triplet_loss
 
         #TODO: report avg logits to wandb for validating our apporach

--- a/ultralytics/utils/loss.py
+++ b/ultralytics/utils/loss.py
@@ -185,7 +185,7 @@ class v8DetectionLoss:
         # Pboxes
         pred_bboxes = self.bbox_decode(anchor_points, pred_distri)  # xyxy, (b, h*w, 4)
 
-        _, target_bboxes, target_scores, fg_mask, _ = self.assigner(
+        target_labels, target_bboxes, target_scores, fg_mask, _ = self.assigner(
             pred_scores.detach().sigmoid(), (pred_bboxes.detach() * stride_tensor).type(gt_bboxes.dtype),
             anchor_points * stride_tensor, gt_labels, gt_bboxes, mask_gt)
 
@@ -204,6 +204,9 @@ class v8DetectionLoss:
         loss[0] *= self.hyp.box  # box gain
         loss[1] *= self.hyp.cls  # cls gain
         loss[2] *= self.hyp.dfl  # dfl gain
+
+        # TODO: pull embeddings
+        # TODO: use target labels and embeddings to create triplet loss
 
         return loss.sum() * batch_size, loss.detach()  # loss(box, cls, dfl)
 

--- a/ultralytics/utils/loss.py
+++ b/ultralytics/utils/loss.py
@@ -462,9 +462,12 @@ class v8PoseLoss(v8DetectionLoss):
         gt_labels = gt_labels.squeeze(-1)  # (bs, n_max_boxes)
 
         for b in range(batch_size):
+            if gt_labels[b].size(0) == 0:  # skip if there is no ground truth boxes and labels for the input image
+                continue
             # for i, idx in enumerate(target_gt_idx[b]):  # find target labels using gt_labels (bs, n_max_boxes, 1) & target_gt_idx (bs, n_total_anchors)
             #     target_labels[i] = gt_labels[b][idx]  # (n_total_anchors,)
-            target_labels = gt_labels[b][target_gt_idx[b]]  # (n_total_anchors,)
+            target_gt_idx_batch = target_gt_idx[b].long()
+            target_labels = gt_labels[b][target_gt_idx_batch]  # (n_total_anchors,)
 
             if fg_mask[b].sum() == 0:  # skip if there is no match between anchors and ground truths
                 continue

--- a/ultralytics/utils/loss.py
+++ b/ultralytics/utils/loss.py
@@ -516,10 +516,9 @@ class v8PoseLoss(v8DetectionLoss):
 
         #TODO: report avg logits to wandb for validating our apporach
         logits_avg /= batch_size
-        loss[6] = logits_avg
-        print("-----------------avg logits", logits_avg)
+        # loss[6] = logits_avg
 
-        return loss[:6].sum() * batch_size, loss.detach()  # loss(box, pose, kobj, cls, dfl, triplet)
+        return loss.sum() * batch_size, loss.detach()  # loss(box, pose, kobj, cls, dfl, triplet)
 
     @staticmethod
     def kpts_decode(anchor_points, pred_kpts):

--- a/ultralytics/utils/loss.py
+++ b/ultralytics/utils/loss.py
@@ -451,7 +451,6 @@ class v8PoseLoss(v8DetectionLoss):
         # fg_mask (B, n_anchors) <-- boolean tensor vector showing which anchor (candidate) has a match with the ground truth
         import torch.nn.functional as F
         triplet_loss = 0
-        triplet_loss1 = 0
         for b in range(batch_size):
             if fg_mask[b].sum() == 0:  # skip if there is no match between anchors and ground truths
                 continue

--- a/ultralytics/utils/loss.py
+++ b/ultralytics/utils/loss.py
@@ -516,9 +516,9 @@ class v8PoseLoss(v8DetectionLoss):
 
         #TODO: report avg logits to wandb for validating our apporach
         logits_avg /= batch_size
-        # loss[6] = logits_avg
+        loss[6] = logits_avg
 
-        return loss.sum() * batch_size, loss.detach()  # loss(box, pose, kobj, cls, dfl, triplet)
+        return loss[:6].sum() * batch_size, loss.detach()  # loss(box, pose, kobj, cls, dfl, triplet)
 
     @staticmethod
     def kpts_decode(anchor_points, pred_kpts):

--- a/ultralytics/utils/loss.py
+++ b/ultralytics/utils/loss.py
@@ -387,7 +387,7 @@ class v8PoseLoss(v8DetectionLoss):
 
     def __call__(self, preds, batch):
         """Calculate the total loss and detach it."""
-        loss = torch.zeros(7, device=self.device)  # box, cls, dfl, kpt_location, kpt_visibility, triplet loss and avg_logits
+        loss = torch.zeros(5, device=self.device)  # box, cls, dfl, kpt_location, kpt_visibility
         feats, pred_kpts = preds if isinstance(preds[0], list) else preds[1]
         pred_distri, pred_scores = torch.cat([xi.view(feats[0].shape[0], self.no, -1) for xi in feats], 2).split(
             (self.reg_max * 4, self.nc), 1)

--- a/ultralytics/utils/plotting.py
+++ b/ultralytics/utils/plotting.py
@@ -666,7 +666,7 @@ def feature_visualization(x, module_type, stage, n=32, save_dir=Path('runs/detec
         n (int, optional): Maximum number of feature maps to plot. Defaults to 32.
         save_dir (Path, optional): Directory to save results. Defaults to Path('runs/detect/exp').
     """
-    for m in ['Detect', 'Pose', 'Segment']:
+    for m in ['Detect', 'DetectContrastive', 'Pose', 'PoseContrastive', 'Segment']:
         if m in module_type:
             return
     batch, channels, height, width = x.shape  # batch, channels, height, width


### PR DESCRIPTION
This modification implements triplet loss in YOLOv8 Pose model for contrastive learning.
It allows the user to create a docker container for running simple training with different task (e.g., detect, pose, pose-contrastive). Therefore, the user has options to train a YOLOv8 Pose model with either the default settings or contrastive learning (triplet loss & single label for classification).

-----------------------------TEST-----------------------------
1. Go to `~/verdant/dev/src/python/trainers/yolo8` in your server (e.g., neptune).
2. If you are in `master` branch of dev, the `Dockerfile` in this directory will clone a new verdant ultralytics repository's `main` branch. However, these changes (for triplet loss) have not been merged into the `main` branch yet. 
3. One work around is to checkout `jonghoon/yolo8_docker` branch in the `dev` repo. This branch has modified Dockerfile and `start.sh` to mount your local ultralytics repo to the docker container.
4. Thus, clone the verdant ultralytics repo locally and checkout to 'jonghoon/feature_embeddings' branch (this is the branch that I am trying to merge through this Pull Request).
Example: I cloned the verdant ultralytics repo as `ultralytics` in `~/verdant/dev/src/python/trainers/yolo8`.
6. Then, run  `./start.sh {your dataset path}/ runs {task} shell {local ultralytics dir}` from `~/verdant/dev/src/python/trainers/yolo8`. 
![image](https://github.com/user-attachments/assets/765ddfd1-8386-4fb0-828f-6202b17d8370)
7. Example for **Pose** task: `./start.sh ~/data/onion4fira_24.9/ runs pose shell ~/verdant/dev/src/python/trainers/yolo8/ultralytics `
8. Example for **Pose-Contrastive** task: `./start.sh ~/data/onion4fira_24.9/ runs pose-contrastive shell ~/verdant/dev/src/python/trainers/yolo8/ultralytics `
9. Once the docker container is created and you are inside for interactive mode, you can type in `python simple_training.py` 
![image](https://github.com/user-attachments/assets/1716aaec-bf19-4c81-a554-bccfb4e04901)
10. Once the training begins, you can monitor each loss and average logitis in the terminal. The triplet loss and average logits will always 0 for the tasks other than `Pose-Contrastive`. 
![image](https://github.com/user-attachments/assets/7889dab5-2d3c-4553-b234-6d054b87cf68)

