### PR TITLE
Enforce num classes (nc) = 1 for pose-contrastive task

### DIFF
--- a/training_utils/training_utils.py
+++ b/training_utils/training_utils.py
@@ -27,7 +27,7 @@ def PrepareDataset(coco_classes_file, dataset_yaml, training_task):
         for i in range(len(classes)):
             f.write(f"  {i}: {classes[i]}\n")
         if training_task == "pose" or training_task == "pose-contrastive":
-            f.write("\nkpt_shape: [1, 3]\n")
+            f.write("\nkpt_shape: [1, 3]\n")  # enforce keypoint shape to [1, 3] for pose models
     return
 
 

--- a/ultralytics/data/utils.py
+++ b/ultralytics/data/utils.py
@@ -303,7 +303,13 @@ def check_det_dataset(dataset, autodownload=True):
     if 'names' not in data:
         data['names'] = [f'class_{i}' for i in range(data['nc'])]
     else:
-        data['nc'] = len(data['names'])
+        training_task = os.environ.get("TASK")
+        # for pose-contrastive task, enfoce num classes to be 1
+        if training_task == 'pose-contrastive':
+            data['nc'] = 1
+            print("Setting nc to 1 for pose-contrastive task")
+        else:
+            data['nc'] = len(data['names'])
 
     data['names'] = check_class_names(data['names'])
 


### PR DESCRIPTION
This modification enforces the YOLOv8 Pose model's pose-contrastive task (using triplet loss) to use `nc (num classes) = 1`.

If we do not enforce `nc (num classes) = 1` in `ultralytics/data/untils.py` (for example, if you enforce it in `ultralytics/nn/modules/head.py`), the `nc` will be overwritten by `data['nc'] = len(data['names'])` defined in `ultralytics/data/untils.py` which is not desirable.

Once the user creates and runs a docker container using `./start.sh ~/data/<your dataset path>/ runs pose shell ~/verdant/dev/src/python/trainers/yolo8/ultralytics`, `'pose-contrastive'` will be set as a 'TASK' environment variable. The modification in `ultralytics/data/untils.py` will enforce `nc = 1` if `'TASK' == 'pose-contrastive'`.

This is for efficient computing as the `pd_scores (predicted scores for anchors vs. classes) `tensor in `TaskAlignedAssigner` in `tal.py` will have a smaller class dimension (e.g., (B,12096,2) --> (B,12096,1)).

-----------------------------TEST-----------------------------
1. Go to `~/verdant/dev/src/python/trainers/yolo8` in your server (e.g., neptune).
2. If you are in `master` branch of dev, the `Dockerfile` in this directory will clone a new verdant ultralytics repository's `main` branch. However, these changes (for triplet loss) have not been merged into the `main` branch yet. 
3. One work around is to checkout `jonghoon/yolo8_docker` branch in the `dev` repo. This branch has modified Dockerfile and `start.sh` to mount your local ultralytics repo to the docker container.
4. Thus, clone the verdant ultralytics repo locally and checkout to 'jonghoon/feature_embeddings' branch (this is the branch that I am trying to merge through this Pull Request).
Example: I cloned the verdant ultralytics repo as `ultralytics` in `~/verdant/dev/src/python/trainers/yolo8`.
5. Then, run  `./start.sh {your dataset path}/ runs {task} shell {local ultralytics dir}` from `~/verdant/dev/src/python/trainers/yolo8`. 
![image](https://github.com/user-attachments/assets/765ddfd1-8386-4fb0-828f-6202b17d8370)
6. Example for **Pose** task: `./start.sh ~/data/onion4fira_24.9/ runs pose shell ~/verdant/dev/src/python/trainers/yolo8/ultralytics `
7. Example for **Pose-Contrastive** task: `./start.sh ~/data/onion4fira_24.9/ runs pose-contrastive shell ~/verdant/dev/src/python/trainers/yolo8/ultralytics `
8. Once the docker container is created and you are inside for interactive mode, you can type in `python simple_training.py` 
![image](https://github.com/user-attachments/assets/1716aaec-bf19-4c81-a554-bccfb4e04901)
9. Confirm that the model is being trained without any errors.