### PR TITLE
[VRS-922] Fix cluster training

### DIFF
--- a/ultralytics/data/build.py
+++ b/ultralytics/data/build.py
@@ -90,7 +90,7 @@ def build_yolo_dataset(cfg, img_path, batch, data, mode='train', rect=False, str
         pad=0.0 if mode == 'train' else 0.5,
         prefix=colorstr(f'{mode}: '),
         use_segments=cfg.task == 'segment',
-        use_keypoints=cfg.task == 'pose',
+        use_keypoints=cfg.task in {'pose', 'pose-contrastive'},
         classes=cfg.classes,
         data=data,
         fraction=cfg.fraction if mode == 'train' else 1.0)

--- a/ultralytics/data/utils.py
+++ b/ultralytics/data/utils.py
@@ -307,11 +307,12 @@ def check_det_dataset(dataset, autodownload=True):
         # for pose-contrastive task, enfoce num classes to be 1
         if training_task == 'pose-contrastive':
             data['nc'] = 1
+            data['names'] = {0: 'plant'}
             print("Setting nc to 1 for pose-contrastive task")
         else:
             data['nc'] = len(data['names'])
+            data['names'] = check_class_names(data['names'])
 
-    data['names'] = check_class_names(data['names'])
 
     # Resolve paths
     path = Path(extract_dir or data.get('path') or Path(data.get('yaml_file', '')).parent)  # dataset root

--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -238,7 +238,7 @@ class Exporter:
             'batch': self.args.batch,
             'imgsz': self.imgsz,
             'names': model.names}  # model metadata
-        if model.task == 'pose':
+        if model.task in {'pose', 'pose-contrastive'}:
             self.metadata['kpt_shape'] = model.model[-1].kpt_shape
 
         LOGGER.info(f"\n{colorstr('PyTorch:')} starting from '{file}' with input shape {tuple(im.shape)} BCHW and "

--- a/ultralytics/engine/trainer.py
+++ b/ultralytics/engine/trainer.py
@@ -115,7 +115,7 @@ class BaseTrainer:
         try:
             if self.args.task == 'classify':
                 self.data = check_cls_dataset(self.args.data)
-            elif self.args.data.split('.')[-1] in ('yaml', 'yml') or self.args.task in ('detect', 'segment', 'pose'):
+            elif self.args.data.split('.')[-1] in ('yaml', 'yml') or self.args.task in ('detect', 'segment', 'pose', 'pose-contrastive'):
                 self.data = check_det_dataset(self.args.data)
                 if 'yaml_file' in self.data:
                     self.args.data = self.data['yaml_file']  # for validating 'yolo train data=url.zip' usage

--- a/ultralytics/models/yolo/__init__.py
+++ b/ultralytics/models/yolo/__init__.py
@@ -4,4 +4,4 @@ from ultralytics.models.yolo import classify, detect, pose, segment
 
 from .model import YOLO
 
-__all__ = 'classify', 'segment', 'detect', 'pose', 'YOLO'
+__all__ = 'classify', 'segment', 'detect', 'pose', 'pose-contrastive', 'YOLO'

--- a/ultralytics/models/yolo/pose/train.py
+++ b/ultralytics/models/yolo/pose/train.py
@@ -26,7 +26,7 @@ class PoseTrainer(yolo.detect.DetectionTrainer):
         """Initialize a PoseTrainer object with specified configurations and overrides."""
         if overrides is None:
             overrides = {}
-        overrides['task'] = 'pose'
+        overrides['task'] = overrides.get('task', 'pose')
         super().__init__(cfg, overrides, _callbacks)
 
         if isinstance(self.args.device, str) and self.args.device.lower() == 'mps':
@@ -90,7 +90,7 @@ class PoseContrastiveTrainer(PoseTrainer):
         """Initialize a PoseContrastiveTrainer object with specified configurations and overrides."""
         if overrides is None:
             overrides = {}
-        overrides['task'] = 'pose_contrastive'
+        overrides['task'] = 'pose-contrastive'
         super().__init__(cfg, overrides, _callbacks)
 
         if isinstance(self.args.device, str) and self.args.device.lower() == 'mps':

--- a/ultralytics/models/yolo/pose/val.py
+++ b/ultralytics/models/yolo/pose/val.py
@@ -71,7 +71,7 @@ class PoseValidator(DetectionValidator):
         """Metrics."""
         for si, pred in enumerate(preds):
             idx = batch['batch_idx'] == si
-            cls = batch['cls'][idx]
+            cls = batch['cls'][idx].clamp(max=self.nc - 1)
             bbox = batch['bboxes'][idx]
             kpts = batch['keypoints'][idx]
             nl, npr = cls.shape[0], pred.shape[0]  # number of labels, predictions

--- a/ultralytics/nn/modules/head.py
+++ b/ultralytics/nn/modules/head.py
@@ -138,8 +138,9 @@ class DetectContrastive(nn.Module):
             bboxes = self.cv2[i](x[i])  # (B, 4 * reg_max, H, W)
             
             # split embeddings by first half for classification and second half for contrastive task
-            embeddings_cls = self.embedding_layers[i](x[i])[:, :self.c3, :, :]  # (B, n_features for cls, H, W)
-            embeddings_contrastive = self.embedding_layers[i](x[i])[:, self.c3:, :, :]  # (B, n_features for contrastive learning, H, W)
+            full_embedding = self.embedding_layers[i](x[i])
+            embeddings_cls = full_embedding[:, :self.c3, :, :]  # (B, n_features for cls, H, W)
+            embeddings_contrastive = full_embedding[:, self.c3:, :, :]  # (B, n_features for contrastive learning, H, W)
             cls_predictions = self.cls_preds[i](embeddings_cls)  # (B, nc, H, W)
             x[i] = torch.cat((bboxes, cls_predictions, embeddings_contrastive), 1)  # (B, 4 * reg_max + nc + n_features for contrastive learning, H, W) == (B, no, H, W)
             

--- a/ultralytics/utils/loss.py
+++ b/ultralytics/utils/loss.py
@@ -677,21 +677,21 @@ class v8PoseContrastiveLoss(v8PoseLoss):
             # skip if there are not enough classes to make a triplet (it's ok to have query and positive samples from the same class)
             if len(uniq_classes[uniq_classes != 0]) < 2:  # note that class 0 won't be used in the triplet loss
                 continue
-            
-            # crop species: <-1
-            uniq_crop_classes = torch.tensor(list(filter(lambda x: x < -1, uniq_classes)))  # unique crop classes
-
-            # unknown crop: -1
-            unknown_crop_class = -1
 
             # fully unknown: 0
             fully_unknown_class = 0  # won't be used in the triplet loss
+            
+            # crop species: 1 <= x <= 9
+            uniq_crop_classes = torch.tensor(list(filter(lambda x: 1 <= x <= 9, uniq_classes)))  # unique crop classes
 
-            # unknown weed: +1
-            unknown_weed_class = 1
+            # unknown crop: 10
+            unknown_crop_class = 10
 
-            # weed species: >+1
-            uniq_weed_classes = torch.tensor(list(filter(lambda x: x > 1, uniq_classes)))
+            # weed species: 11 <= x <= 19
+            uniq_weed_classes = torch.tensor(list(filter(lambda x: 11 <= x <= 19, uniq_classes)))  # unique weed classes
+
+            # unknown weed: 20
+            unknown_weed_class = 20
 
             def select_rand_idx(n_samples, targets, class_label):
                 """
@@ -707,11 +707,11 @@ class v8PoseContrastiveLoss(v8PoseLoss):
 
                 Example:
                 n_samples = 3, class_label = 2
-                === n_samples x n_matches ===
-                    -5 -2 -1 0 1 2 2 5      <- targets
-                    -5 -2 -1 0 1 2 2 5      <- targets
-                    -5 -2 -1 0 1 2 2 5      <- targets
-                =============================
+                == n_samples x n_matches ==
+                    3 0 1 4 5 2 2 1     <- targets
+                    3 0 1 4 5 2 2 1     <- targets
+                    3 0 1 4 5 2 2 1     <- targets
+                ===========================
                             ...
                     =================
                     0 0 0 0 0 1 1 0  <- masked targets (by class_label)

--- a/ultralytics/utils/loss.py
+++ b/ultralytics/utils/loss.py
@@ -777,6 +777,9 @@ class v8PoseContrastiveLoss(v8PoseLoss):
                 for weed_class in uniq_weed_classes:
                     class_pairs.extend([(weed_class, unknown_crop_class, False), (unknown_crop_class, weed_class, True)])
 
+            if not class_pairs:
+                continue
+
             # sample random n pairs
             n_samples = self.n_samples
             pair_samples = [class_pairs[i] for i in torch.randint(0, len(class_pairs), (n_samples,))]  # redundant pairs are allowed


### PR DESCRIPTION
This fixes several issues in the data specification (class_names should only contain a single class in the case of triplet training), training (the 'pose-contrastive' task was being overwritten with 'pose'), the model export (the embedding layers were not fully used, so they were automatically marked as output). It also extends the loss so that it works with our more complex cluster labels.

Tested:
- Instantiated a cluster dataset
- python simple_training.py