### PR TITLE
Part of #1475 - Enable training of multi-heads model

### DIFF
--- a/training_utils/training_utils.py
+++ b/training_utils/training_utils.py
@@ -26,7 +26,7 @@ def PrepareDataset(coco_classes_file, dataset_yaml, training_task):
         f.write("names:\n")
         for i in range(len(classes)):
             f.write(f"  {i}: {classes[i]}\n")
-        if training_task == "pose" or training_task == "pose-contrastive":
+        if training_task == "pose" or training_task == "pose-contrastive" or training_task == "pose-multiclsheads":
             f.write("\nkpt_shape: [1, 3]\n")  # enforce keypoint shape to [1, 3] for pose models
     return
 
@@ -38,6 +38,8 @@ def GetModelYaml(task):
         return "yolov8n-pose.yaml"
     elif task == "pose-contrastive":
         return "yolov8n-pose-contrastive.yaml"
+    elif task == "pose-multiclsheads":
+        return "yolov8n-pose-multiclsheads.yaml"
     print(f"Unknown task {task}")
     return None
 

--- a/ultralytics/cfg/__init__.py
+++ b/ultralytics/cfg/__init__.py
@@ -13,20 +13,23 @@ from ultralytics.utils import (ASSETS, DEFAULT_CFG, DEFAULT_CFG_DICT, DEFAULT_CF
 
 # Define valid tasks and modes
 MODES = 'train', 'val', 'predict', 'export', 'track', 'benchmark'
-TASKS = 'detect', 'segment', 'classify', 'pose', 'pose-contrastive'
-TASK2DATA = {'detect': 'coco8.yaml', 'segment': 'coco8-seg.yaml', 'classify': 'imagenet10', 'pose': 'coco8-pose.yaml', 'pose-contrastive': 'coco8-pose.yaml'}
+TASKS = 'detect', 'segment', 'classify', 'pose', 'pose-contrastive', 'pose-multiclsheads'
+TASK2DATA = {'detect': 'coco8.yaml', 'segment': 'coco8-seg.yaml', 'classify': 'imagenet10', 
+             'pose': 'coco8-pose.yaml', 'pose-contrastive': 'coco8-pose.yaml', 'pose-multiclsheads': 'coco8-pose.yaml'}
 TASK2MODEL = {
     'detect': 'yolov8n.pt',
     'segment': 'yolov8n-seg.pt',
     'classify': 'yolov8n-cls.pt',
     'pose': 'yolov8n-pose.pt',
-    'pose-contrastive': 'yolov8n-pose-contrastive.pt'}
+    'pose-contrastive': 'yolov8n-pose-contrastive.pt',
+    'pose-multiclsheads': 'yolov8n-pose-multiclsheads.pt'}
 TASK2METRIC = {
     'detect': 'metrics/mAP50-95(B)',
     'segment': 'metrics/mAP50-95(M)',
     'classify': 'metrics/accuracy_top1',
     'pose': 'metrics/mAP50-95(P)',
-    'pose-contrastive': 'metrics/mAP50-95(P)'}
+    'pose-contrastive': 'metrics/mAP50-95(P)',
+    'pose-multiclsheads': 'metrics/mAP50-95(P)'}
 
 CLI_HELP_MSG = \
     f"""

--- a/ultralytics/cfg/default.yaml
+++ b/ultralytics/cfg/default.yaml
@@ -1,7 +1,7 @@
 # Ultralytics YOLO 🚀, AGPL-3.0 license
 # Default training settings and hyperparameters for medium-augmentation COCO training
 
-task: detect  # (str) YOLO task, i.e. detect, segment, classify, pose, pose-contrastive
+task: detect  # (str) YOLO task, i.e. detect, segment, classify, pose, pose-contrastive, pose-multiclsheads
 mode: train  # (str) YOLO mode, i.e. train, val, predict, export, track, benchmark
 
 # Train settings -------------------------------------------------------------------------------------------------------

--- a/ultralytics/cfg/models/v8/yolov8-pose-multiclsheads.yaml
+++ b/ultralytics/cfg/models/v8/yolov8-pose-multiclsheads.yaml
@@ -1,0 +1,47 @@
+# Ultralytics YOLO 🚀, AGPL-3.0 license
+# YOLOv8-pose keypoints/pose estimation model with multiple classification heads. For Usage examples see https://docs.ultralytics.com/tasks/pose
+
+# Parameters
+nc: 1  # number of classes
+kpt_shape: [17, 3]  # number of keypoints, number of dims (2 for x,y or 3 for x,y,visible)
+scales: # model compound scaling constants, i.e. 'model=yolov8n-pose-multiclsheads.yaml' will call yolov8-pose-multiclsheads.yaml with scale 'n'
+  # [depth, width, max_channels]
+  n: [0.33, 0.25, 1024]
+  s: [0.33, 0.50, 1024]
+  m: [0.67, 0.75, 768]
+  l: [1.00, 1.00, 512]
+  x: [1.00, 1.25, 512]
+
+# YOLOv8.0n backbone
+backbone:
+  # [from, repeats, module, args]
+  - [-1, 1, Conv, [64, 3, 2]]  # 0-P1/2
+  - [-1, 1, Conv, [128, 3, 2]]  # 1-P2/4
+  - [-1, 3, C2f, [128, True]]
+  - [-1, 1, Conv, [256, 3, 2]]  # 3-P3/8
+  - [-1, 6, C2f, [256, True]]
+  - [-1, 1, Conv, [512, 3, 2]]  # 5-P4/16
+  - [-1, 6, C2f, [512, True]]
+  - [-1, 1, Conv, [1024, 3, 2]]  # 7-P5/32
+  - [-1, 3, C2f, [1024, True]]
+  - [-1, 1, SPPF, [1024, 5]]  # 9
+
+# YOLOv8.0n head
+head:
+  - [-1, 1, nn.Upsample, [None, 2, 'nearest']]
+  - [[-1, 6], 1, Concat, [1]]  # cat backbone P4
+  - [-1, 3, C2f, [512]]  # 12
+
+  - [-1, 1, nn.Upsample, [None, 2, 'nearest']]
+  - [[-1, 4], 1, Concat, [1]]  # cat backbone P3
+  - [-1, 3, C2f, [256]]  # 15 (P3/8-small)
+
+  - [-1, 1, Conv, [256, 3, 2]]
+  - [[-1, 12], 1, Concat, [1]]  # cat head P4
+  - [-1, 3, C2f, [512]]  # 18 (P4/16-medium)
+
+  - [-1, 1, Conv, [512, 3, 2]]
+  - [[-1, 9], 1, Concat, [1]]  # cat head P5
+  - [-1, 3, C2f, [1024]]  # 21 (P5/32-large)
+  
+  - [[15, 18, 21], 1, PoseMultiClsHeads, [nc, kpt_shape]]  # Pose(P3, P4, P5)

--- a/ultralytics/data/build.py
+++ b/ultralytics/data/build.py
@@ -90,7 +90,7 @@ def build_yolo_dataset(cfg, img_path, batch, data, mode='train', rect=False, str
         pad=0.0 if mode == 'train' else 0.5,
         prefix=colorstr(f'{mode}: '),
         use_segments=cfg.task == 'segment',
-        use_keypoints=cfg.task in {'pose', 'pose-contrastive'},
+        use_keypoints=cfg.task in {'pose', 'pose-contrastive', 'pose-multiclsheads'},
         classes=cfg.classes,
         data=data,
         fraction=cfg.fraction if mode == 'train' else 1.0)

--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -65,8 +65,8 @@ from ultralytics.cfg import get_cfg
 from ultralytics.data.dataset import YOLODataset
 from ultralytics.data.utils import check_det_dataset
 from ultralytics.nn.autobackend import check_class_names
-from ultralytics.nn.modules import C2f, Detect, RTDETRDecoder, DetectContrastive
-from ultralytics.nn.tasks import DetectionModel, SegmentationModel, PoseContrastiveModel
+from ultralytics.nn.modules import C2f, Detect, RTDETRDecoder, DetectContrastive, DetectMultiClsHeads
+from ultralytics.nn.tasks import DetectionModel, SegmentationModel, PoseContrastiveModel, PoseMultiClsHeadsModel
 from ultralytics.utils import (ARM64, DEFAULT_CFG, LINUX, LOGGER, MACOS, ROOT, WINDOWS, __version__, callbacks,
                                colorstr, get_default_args, yaml_save)
 from ultralytics.utils.checks import check_imgsz, check_requirements, check_version
@@ -199,7 +199,7 @@ class Exporter:
         model.float()
         model = model.fuse()
         for m in model.modules():
-            if isinstance(m, (Detect, DetectContrastive, RTDETRDecoder)):  # Segment and Pose use Detect base class
+            if isinstance(m, (Detect, DetectContrastive, DetectMultiClsHeads, RTDETRDecoder)):  # Segment and Pose use Detect base class
                 m.dynamic = self.args.dynamic
                 m.export = True
                 m.format = self.args.format
@@ -238,7 +238,7 @@ class Exporter:
             'batch': self.args.batch,
             'imgsz': self.imgsz,
             'names': model.names}  # model metadata
-        if model.task in {'pose', 'pose-contrastive'}:
+        if model.task in {'pose', 'pose-contrastive', 'pose-multiclsheads'}:
             self.metadata['kpt_shape'] = model.model[-1].kpt_shape
 
         LOGGER.info(f"\n{colorstr('PyTorch:')} starting from '{file}' with input shape {tuple(im.shape)} BCHW and "

--- a/ultralytics/engine/trainer.py
+++ b/ultralytics/engine/trainer.py
@@ -115,7 +115,8 @@ class BaseTrainer:
         try:
             if self.args.task == 'classify':
                 self.data = check_cls_dataset(self.args.data)
-            elif self.args.data.split('.')[-1] in ('yaml', 'yml') or self.args.task in ('detect', 'segment', 'pose', 'pose-contrastive'):
+            elif self.args.data.split('.')[-1] in ('yaml', 'yml') or self.args.task in ('detect', 'segment', 
+                                                                                        'pose', 'pose-contrastive', 'pose-multiclsheads'):
                 self.data = check_det_dataset(self.args.data)
                 if 'yaml_file' in self.data:
                     self.args.data = self.data['yaml_file']  # for validating 'yolo train data=url.zip' usage

--- a/ultralytics/models/yolo/__init__.py
+++ b/ultralytics/models/yolo/__init__.py
@@ -4,4 +4,4 @@ from ultralytics.models.yolo import classify, detect, pose, segment
 
 from .model import YOLO
 
-__all__ = 'classify', 'segment', 'detect', 'pose', 'pose-contrastive', 'YOLO'
+__all__ = 'classify', 'segment', 'detect', 'pose', 'pose-contrastive', 'pose-multiclsheads', 'YOLO'

--- a/ultralytics/models/yolo/model.py
+++ b/ultralytics/models/yolo/model.py
@@ -2,7 +2,8 @@
 
 from ultralytics.engine.model import Model
 from ultralytics.models import yolo  # noqa
-from ultralytics.nn.tasks import ClassificationModel, DetectionModel, PoseModel, PoseContrastiveModel, SegmentationModel
+from ultralytics.nn.tasks import (ClassificationModel, DetectionModel, PoseModel, PoseContrastiveModel, 
+                                  PoseMultiClsHeadsModel, SegmentationModel)
 
 
 class YOLO(Model):
@@ -36,4 +37,10 @@ class YOLO(Model):
                 'model': PoseContrastiveModel,
                 'trainer': yolo.pose.PoseContrastiveTrainer,
                 'validator': yolo.pose.PoseValidator,
-                'predictor': yolo.pose.PosePredictor, }, }
+                'predictor': yolo.pose.PosePredictor, },
+            'pose-multiclsheads': {
+                'model': PoseMultiClsHeadsModel,
+                'trainer': yolo.pose.PoseMultiClsHeadsTrainer,
+                'validator': yolo.pose.PoseValidator,
+                'predictor': yolo.pose.PosePredictor, },
+            }

--- a/ultralytics/models/yolo/pose/__init__.py
+++ b/ultralytics/models/yolo/pose/__init__.py
@@ -1,7 +1,7 @@
 # Ultralytics YOLO 🚀, AGPL-3.0 license
 
 from .predict import PosePredictor
-from .train import PoseTrainer, PoseContrastiveTrainer
+from .train import PoseTrainer, PoseContrastiveTrainer, PoseMultiClsHeadsTrainer
 from .val import PoseValidator
 
-__all__ = 'PoseTrainer', 'PoseContrastiveTrainer', 'PoseValidator', 'PosePredictor'
+__all__ = 'PoseTrainer', 'PoseContrastiveTrainer', 'PoseMultiClsHeadsTrainer', 'PoseValidator', 'PosePredictor'

--- a/ultralytics/models/yolo/pose/train.py
+++ b/ultralytics/models/yolo/pose/train.py
@@ -3,7 +3,7 @@
 from copy import copy
 
 from ultralytics.models import yolo
-from ultralytics.nn.tasks import PoseModel, PoseContrastiveModel
+from ultralytics.nn.tasks import PoseModel, PoseContrastiveModel, PoseMultiClsHeadsModel
 from ultralytics.utils import DEFAULT_CFG, LOGGER
 from ultralytics.utils.plotting import plot_images, plot_results
 
@@ -100,6 +100,39 @@ class PoseContrastiveTrainer(PoseTrainer):
     def get_model(self, cfg=None, weights=None, verbose=True):
         """Get pose estimation model with specified configuration and weights."""
         model = PoseContrastiveModel(cfg, ch=3, nc=self.data['nc'], data_kpt_shape=self.data['kpt_shape'], verbose=verbose)
+        if weights:
+            model.load(weights)
+
+        return model
+
+
+class PoseMultiClsHeadsTrainer(PoseTrainer):
+    """
+    A class extending the DetectionTrainer class for training based on a pose model.
+
+    Example:
+        ```python
+        from ultralytics.models.yolo.pose import PoseMultiClsHeadsTrainer
+
+        args = dict(model='yolov8n-pose-multiclsheads.pt', data='coco8-pose.yaml', epochs=3)
+        trainer = PoseMultiClsHeadsTrainer(overrides=args)
+        trainer.train()
+        ```
+    """
+    def __init__(self, cfg=DEFAULT_CFG, overrides=None, _callbacks=None):
+        """Initialize a PoseMultiClsHeadsTrainer object with specified configurations and overrides."""
+        if overrides is None:
+            overrides = {}
+        overrides['task'] = 'pose-multiclsheads'
+        super().__init__(cfg, overrides, _callbacks)
+
+        if isinstance(self.args.device, str) and self.args.device.lower() == 'mps':
+            LOGGER.warning("WARNING ⚠️ Apple MPS known Pose bug. Recommend 'device=cpu' for Pose models. "
+                           'See https://github.com/ultralytics/ultralytics/issues/4031.')
+            
+    def get_model(self, cfg=None, weights=None, verbose=True):
+        """Get pose estimation model with specified configuration and weights."""
+        model = PoseMultiClsHeadsModel(cfg, ch=3, nc=self.data['nc'], data_kpt_shape=self.data['kpt_shape'], verbose=verbose)
         if weights:
             model.load(weights)
 

--- a/ultralytics/nn/modules/__init__.py
+++ b/ultralytics/nn/modules/__init__.py
@@ -21,13 +21,14 @@ from .block import (C1, C2, C3, C3TR, DFL, SPP, SPPF, Bottleneck, BottleneckCSP,
                     HGBlock, HGStem, Proto, RepC3)
 from .conv import (CBAM, ChannelAttention, Concat, Conv, Conv2, ConvTranspose, DWConv, DWConvTranspose2d, Focus,
                    GhostConv, LightConv, RepConv, SpatialAttention)
-from .head import Classify, Detect, DetectContrastive, Pose, PoseContrastive, RTDETRDecoder, Segment
+from .head import (Classify, Detect, DetectContrastive, DetectMultiClsHeads, Pose, PoseContrastive, PoseMultiClsHeads, 
+                   RTDETRDecoder, Segment)
 from .transformer import (AIFI, MLP, DeformableTransformerDecoder, DeformableTransformerDecoderLayer, LayerNorm2d,
                           MLPBlock, MSDeformAttn, TransformerBlock, TransformerEncoderLayer, TransformerLayer)
 
 __all__ = ('Conv', 'Conv2', 'LightConv', 'RepConv', 'DWConv', 'DWConvTranspose2d', 'ConvTranspose', 'Focus',
            'GhostConv', 'ChannelAttention', 'SpatialAttention', 'CBAM', 'Concat', 'TransformerLayer',
            'TransformerBlock', 'MLPBlock', 'LayerNorm2d', 'DFL', 'HGBlock', 'HGStem', 'SPP', 'SPPF', 'C1', 'C2', 'C3',
-           'C2f', 'C3x', 'C3TR', 'C3Ghost', 'GhostBottleneck', 'Bottleneck', 'BottleneckCSP', 'Proto', 'Detect', 'DetectContrastive',
-           'Segment', 'Pose', 'PoseContrastive', 'Classify', 'TransformerEncoderLayer', 'RepC3', 'RTDETRDecoder', 'AIFI',
-           'DeformableTransformerDecoder', 'DeformableTransformerDecoderLayer', 'MSDeformAttn', 'MLP')
+           'C2f', 'C3x', 'C3TR', 'C3Ghost', 'GhostBottleneck', 'Bottleneck', 'BottleneckCSP', 'Proto', 'Detect', 'DetectContrastive', 
+           'DetectMultiClsHeads', 'Segment', 'Pose', 'PoseContrastive', 'PoseMultiClsHeads', 'Classify', 'TransformerEncoderLayer', 
+           'RepC3', 'RTDETRDecoder', 'AIFI', 'DeformableTransformerDecoder', 'DeformableTransformerDecoderLayer', 'MSDeformAttn', 'MLP')

--- a/ultralytics/nn/modules/head.py
+++ b/ultralytics/nn/modules/head.py
@@ -14,7 +14,8 @@ from .conv import Conv
 from .transformer import MLP, DeformableTransformerDecoder, DeformableTransformerDecoderLayer
 from .utils import bias_init_with_prob, linear_init_
 
-__all__ = 'Detect', 'DetectContrastive', 'Segment', 'Pose', 'PoseContrastive', 'Classify', 'RTDETRDecoder'
+__all__ = ('Detect', 'DetectContrastive', 'DetectMultiClsHeads', 'Segment', 
+           'Pose', 'PoseContrastive', 'PoseMultiClsHeads', 'Classify', 'RTDETRDecoder')
 
 class Detect(nn.Module):
     """YOLOv8 Detect head for detection models."""
@@ -35,25 +36,14 @@ class Detect(nn.Module):
         c2, c3 = max(16, ch[0] // 4, self.reg_max * 4), max(ch[0], min(self.nc, 100))  # channels
         self.cv2 = nn.ModuleList(
             nn.Sequential(Conv(x, c2, 3), Conv(c2, c2, 3), nn.Conv2d(c2, 4 * self.reg_max, 1)) for x in ch)
-        # self.cv3 = nn.ModuleList(nn.Sequential(Conv(x, c3, 3), Conv(c3, c3, 3), nn.Conv2d(c3, self.nc, 1)) for x in ch)
-
-        import math
-        self.num_heads = math.ceil(self.nc / 2)
-        self.num_cls_per_head = math.ceil(self.nc / self.num_heads)
-        self.cv3 = nn.ModuleList(nn.Sequential(Conv(x, c3, 3), Conv(c3, c3, 3)) for x in ch)
-        self.heads = nn.ModuleList([nn.ModuleList([nn.Conv2d(c3, self.num_cls_per_head, 1) for _ in range(self.num_heads)]) for _ in range(self.nl)])
-        
+        self.cv3 = nn.ModuleList(nn.Sequential(Conv(x, c3, 3), Conv(c3, c3, 3), nn.Conv2d(c3, self.nc, 1)) for x in ch)
         self.dfl = DFL(self.reg_max) if self.reg_max > 1 else nn.Identity()
 
     def forward(self, x):
         """Concatenates and returns predicted bounding boxes and class probabilities."""
         shape = x[0].shape  # BCHW
         for i in range(self.nl):  # per detection scale
-            # x[i] = torch.cat((self.cv2[i](x[i]), self.cv3[i](x[i])), 1)
-            neck = self.cv3[i](x[i])
-            cv2_output = self.cv2[i](x[i])
-            head_outputs = [head(neck) for head in self.heads[i]]
-            x[i] = torch.cat((cv2_output, *head_outputs), 1)
+            x[i] = torch.cat((self.cv2[i](x[i]), self.cv3[i](x[i])), 1)
         if self.training:
             return x
         elif self.dynamic or self.shape != shape:
@@ -85,13 +75,9 @@ class Detect(nn.Module):
         m = self  # self.model[-1]  # Detect() module
         # cf = torch.bincount(torch.tensor(np.concatenate(dataset.labels, 0)[:, 0]).long(), minlength=nc) + 1
         # ncf = math.log(0.6 / (m.nc - 0.999999)) if cf is None else torch.log(cf / cf.sum())  # nominal class frequency
-        # for a, b, s in zip(m.cv2, m.cv3, m.stride):  # from
-        #     a[-1].bias.data[:] = 1.0  # box
-        #     b[-1].bias.data[:m.nc] = math.log(5 / m.nc / (640 / s) ** 2)  # cls (.01 objects, 80 classes, 640 img)
-        for a, heads, s in zip(m.cv2, m.heads, m.stride):  # from
+        for a, b, s in zip(m.cv2, m.cv3, m.stride):  # from
             a[-1].bias.data[:] = 1.0  # box
-            for b in heads:
-                b.bias.data[:m.num_cls_per_head] = math.log(5 / m.num_cls_per_head / (640 / s) ** 2)  # cls (.01 objects, 80 classes, 640 img)
+            b[-1].bias.data[:m.nc] = math.log(5 / m.nc / (640 / s) ** 2)  # cls (.01 objects, 80 classes, 640 img)
 
 
 class DetectContrastive(nn.Module):
@@ -186,6 +172,77 @@ class DetectContrastive(nn.Module):
         for a, s in zip(m.cv2, m.stride):  # from
             a[-1].bias.data[:] = 1.0  # box
         self.shared_conv.bias.data[:m.nc] = math.log(5 / m.nc / (640 / s) ** 2)  # cls (.01 objects, 80 classes, 640 img)
+
+
+class DetectMultiClsHeads(nn.Module):
+    """YOLOv8 Detect head for detection models with multi-classification heads."""
+    dynamic = False  # force grid reconstruction
+    export = False  # export mode
+    shape = None
+    anchors = torch.empty(0)  # init
+    strides = torch.empty(0)  # init
+    
+    def __init__(self, nc=80, ch=()):
+        """Initializes the YOLOv8 detection layer with specified number of classes and channels."""
+        super().__init__()
+        self.nc = nc  # number of classes
+        self.nl = len(ch)  # number of detection layers (e.g., small, medium, large for 3-scale detections)
+        self.reg_max = 16  # DFL channels (ch[0] // 16 to scale 4/8/12/16/20 for n/s/m/l/x)
+        self.no = nc + self.reg_max * 4  # number of outputs per anchor
+        self.stride = torch.zeros(self.nl)  # strides computed during build
+        self.dfl = DFL(self.reg_max) if self.reg_max > 1 else nn.Identity()
+
+        c2, c3 = max(16, ch[0] // 4, self.reg_max * 4), max(ch[0], min(self.nc, 100))  # channels
+        self.cv2 = nn.ModuleList(
+            nn.Sequential(Conv(x, c2, 3), Conv(c2, c2, 3), nn.Conv2d(c2, 4 * self.reg_max, 1)) for x in ch)
+
+        self.num_heads = math.ceil(self.nc / 2)
+        self.num_cls_per_head = math.ceil(self.nc / self.num_heads)
+        self.cv3 = nn.ModuleList(nn.Sequential(Conv(x, c3, 3), Conv(c3, c3, 3)) for x in ch)
+        self.heads = nn.ModuleList([nn.ModuleList([nn.Conv2d(c3, self.num_cls_per_head, 1) for _ in range(self.num_heads)]) for _ in range(self.nl)])
+
+    def forward(self, x):
+        """Concatenates and returns predicted bounding boxes and class probabilities."""
+        shape = x[0].shape  # BCHW
+        for i in range(self.nl):  # per detection scale
+            neck = self.cv3[i](x[i])
+            cv2_output = self.cv2[i](x[i])
+            head_outputs = [head(neck) for head in self.heads[i]]
+            x[i] = torch.cat((cv2_output, *head_outputs), 1)
+        
+        if self.training:
+            return x
+        elif self.dynamic or self.shape != shape:
+            self.anchors, self.strides = (x.transpose(0, 1) for x in make_anchors(x, self.stride, 0.5))
+            self.shape = shape
+
+        x_cat = torch.cat([xi.view(shape[0], self.no, -1) for xi in x], 2)
+        if self.export and self.format in ('saved_model', 'pb', 'tflite', 'edgetpu', 'tfjs'):  # avoid TF FlexSplitV ops
+            box = x_cat[:, :self.reg_max * 4]
+            cls = x_cat[:, self.reg_max * 4:]
+        else:
+            box, cls = x_cat.split((self.reg_max * 4, self.nc), 1)
+        dbox = dist2bbox(self.dfl(box), self.anchors.unsqueeze(0), xywh=True, dim=1) * self.strides
+
+        if self.export and self.format in ('tflite', 'edgetpu'):
+            # Normalize xywh with image size to mitigate quantization error of TFLite integer models as done in YOLOv5:
+            # https://github.com/ultralytics/yolov5/blob/0c8de3fca4a702f8ff5c435e67f378d1fce70243/models/tf.py#L307-L309
+            # See this PR for details: https://github.com/ultralytics/ultralytics/pull/1695
+            img_h = shape[2] * self.stride[0]
+            img_w = shape[3] * self.stride[0]
+            img_size = torch.tensor([img_w, img_h, img_w, img_h], device=dbox.device).reshape(1, 4, 1)
+            dbox /= img_size
+
+        y = torch.cat((dbox, cls.sigmoid()), 1)
+        return y if self.export else (y, x)
+
+    def bias_init(self):
+        """Initialize Detect() biases, WARNING: requires stride availability."""
+        for a, heads, s in zip(self.cv2, self.heads, self.stride):
+            a[-1].bias.data[:] = 1.0  # bias initalization for bbox attributes regression path
+            for b in heads:
+                # bias initialization for classification path per head
+                b.bias.data[:self.num_cls_per_head] = math.log(5 / self.num_cls_per_head / (640 / s) ** 2)
 
 
 class Segment(Detect):
@@ -301,6 +358,46 @@ class PoseContrastive(DetectContrastive):
             y[:, 1::ndim] = (y[:, 1::ndim] * 2.0 + (self.anchors[1] - 0.5)) * self.strides
             return y
 
+
+class PoseMultiClsHeads(DetectMultiClsHeads):
+    """YOLOv8 Pose head for keypoints models."""
+
+    def __init__(self, nc=80, kpt_shape=(17, 3), ch=()):
+        """Initialize YOLO network with default parameters and Convolutional Layers."""
+        super().__init__(nc, ch)
+        self.kpt_shape = kpt_shape  # number of keypoints, number of dims (2 for x,y or 3 for x,y,visible)
+        self.nk = kpt_shape[0] * kpt_shape[1]  # number of keypoints total
+        self.detect = DetectMultiClsHeads.forward
+
+        c4 = max(ch[0] // 4, self.nk)
+        self.cv4 = nn.ModuleList(nn.Sequential(Conv(x, c4, 3), Conv(c4, c4, 3), nn.Conv2d(c4, self.nk, 1)) for x in ch)
+
+    def forward(self, x):
+        """Perform forward pass through YOLO model and return predictions."""
+        bs = x[0].shape[0]  # batch size
+        kpt = torch.cat([self.cv4[i](x[i]).view(bs, self.nk, -1) for i in range(self.nl)], -1)  # (bs, 17*3, h*w)
+        x = self.detect(self, x)
+        if self.training:
+            return x, kpt
+        pred_kpt = self.kpts_decode(bs, kpt)
+        return torch.cat([x, pred_kpt], 1) if self.export else (torch.cat([x[0], pred_kpt], 1), (x[1], kpt))
+
+    def kpts_decode(self, bs, kpts):
+        """Decodes keypoints."""
+        ndim = self.kpt_shape[1]
+        if self.export:  # required for TFLite export to avoid 'PLACEHOLDER_FOR_GREATER_OP_CODES' bug
+            y = kpts.view(bs, *self.kpt_shape, -1)
+            a = (y[:, :, :2] * 2.0 + (self.anchors - 0.5)) * self.strides
+            if ndim == 3:
+                a = torch.cat((a, y[:, :, 2:3].sigmoid()), 2)
+            return a.view(bs, self.nk, -1)
+        else:
+            y = kpts.clone()
+            if ndim == 3:
+                y[:, 2::3].sigmoid_()  # inplace sigmoid
+            y[:, 0::ndim] = (y[:, 0::ndim] * 2.0 + (self.anchors[0] - 0.5)) * self.strides
+            y[:, 1::ndim] = (y[:, 1::ndim] * 2.0 + (self.anchors[1] - 0.5)) * self.strides
+            return y  
 
 class Classify(nn.Module):
     """YOLOv8 classification head, i.e. x(b,c1,20,20) to x(b,c2)."""

--- a/ultralytics/utils/loss.py
+++ b/ultralytics/utils/loss.py
@@ -433,7 +433,6 @@ class v8PoseLoss(v8DetectionLoss):
 
         ############################################# slice pred_scores #############################################
         # For each batch (B) & all anchors (N), drop all irrelevant classes (C) from classification predictions
-        print(f"pred_scores.shape: {pred_scores.shape}, field_classes.shape: {field_classes.shape}, gt_labels.shape: {gt_labels.shape}")
         for b, c in enumerate(field_classes):
             c_offset = c * 2  # 0 -> 0, 1 -> 2, 2 -> 4, ... where label 2 will actually mean class 4 (crop) or 5 (weed) in the crop field C
             pred_scores[b, :, 0:2] = pred_scores[b, :, c_offset:c_offset+2]  # bring classes (crop & weed for the field) to the front

--- a/ultralytics/utils/plotting.py
+++ b/ultralytics/utils/plotting.py
@@ -666,7 +666,7 @@ def feature_visualization(x, module_type, stage, n=32, save_dir=Path('runs/detec
         n (int, optional): Maximum number of feature maps to plot. Defaults to 32.
         save_dir (Path, optional): Directory to save results. Defaults to Path('runs/detect/exp').
     """
-    for m in ['Detect', 'DetectContrastive', 'Pose', 'PoseContrastive', 'Segment']:
+    for m in ['Detect', 'DetectContrastive', 'DetectMultiClsHeads', 'Pose', 'PoseContrastive', 'PoseMultiClsHeads', 'Segment']:
         if m in module_type:
             return
     batch, channels, height, width = x.shape  # batch, channels, height, width


### PR DESCRIPTION
This revision of the Ultrallytics library allows multi-heads training from its dedicated classes (Model, Loss, Detect, Pose).
The assigned name for this multi-heads training task is "pose-multiclsheads".

==== Test ====
`./start.sh <dataset dir> <save_path> <task> shell -u <local ultralytics dir to mount> -c <name of container to create>`

- I trained a model with pose-multiclsheads task for 100 epochs on a merged dataset.
- I modified the saved onnx file of this trained model to select only one classification head.
- I evaluated it on an out-of-distribution (not seen by the model) data.

More details: https://www.notion.so/Training-19383cede6a5806fba09c46d464bcf0f?pvs=4
