### PR TITLE
Enforce Meristem Flipping - Related to FFR #1604

### DIFF
--- a/training_utils/training_utils.py
+++ b/training_utils/training_utils.py
@@ -28,6 +28,7 @@ def PrepareDataset(coco_classes_file, dataset_yaml, training_task):
             f.write(f"  {i}: {classes[i]}\n")
         if training_task == "pose" or training_task == "pose-contrastive" or training_task == "pose-multiclsheads":
             f.write("\nkpt_shape: [1, 3]\n")  # enforce keypoint shape to [1, 3] for pose models
+            f.write("flip_idx: [0]")  # enforce left-right flipping of keypoints
     return
 
 

--- a/training_utils/training_utils.py
+++ b/training_utils/training_utils.py
@@ -28,7 +28,7 @@ def PrepareDataset(coco_classes_file, dataset_yaml, training_task):
             f.write(f"  {i}: {classes[i]}\n")
         if training_task == "pose" or training_task == "pose-contrastive" or training_task == "pose-multiclsheads":
             f.write("\nkpt_shape: [1, 3]\n")  # enforce keypoint shape to [1, 3] for pose models
-            f.write("flip_idx: [0]")  # enforce left-right flipping of keypoints
+            f.write("flip_idx: [0]\n")  # enforce left-right flipping of keypoints
     return
 
 


### PR DESCRIPTION
## Context
This enforces left-right meristem flipping during model training.
The default hyp.fliplr is 0.5.
Running simple_training.py will automatically generate a verdant.yaml with flip_idx = [0] when the task is pose, pose-contrastive, or pose-multiclsheads.

## Test
./start.sh <data dir> <runs dir> <task> shell -u <local ultralytics repo dir to mount> -c <name of container to create>
./start.sh ~/data/sample_multicrop_012325/ ~/data/runs pose shell -u ~/verdant/ultralytics -c flip_investigation