### PR TITLE
define dt before referencing it

### DIFF
--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -112,13 +112,15 @@ def try_export(inner_func):
     def outer_func(*args, **kwargs):
         """Export a model."""
         prefix = inner_args['prefix']
+        dt = None
         try:
             with Profile() as dt:
                 f, model = inner_func(*args, **kwargs)
             LOGGER.info(f"{prefix} export success ✅ {dt.t:.1f}s, saved as '{f}' ({file_size(f):.1f} MB)")
             return f, model
         except Exception as e:
-            LOGGER.info(f'{prefix} export failure ❌ {dt.t:.1f}s: {e}')
+            time_passed = f"{dt.t:.1f}s" if dt else 'unknown elapsed time'
+            LOGGER.info(f'{prefix} export failure ❌ {time_passed}: {e}')
             raise e
 
     return outer_func


### PR DESCRIPTION
When an onnx file generation fails inside the try loop, it executes the except loop. However the variable `dt` was not defined before referencing it inside the except loop which prevents the error message from being printed.
Made a quick fix made to assign `dt` before referencing it in the except loop.