### PR TITLE
Add a parser argument to tdisablewandb logging

### DIFF
--- a/training_utils/simple_training.py
+++ b/training_utils/simple_training.py
@@ -18,6 +18,7 @@ from export import Export
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="Train the model")
     parser.add_argument("-l", "--load", type=str, default=None, help="Path to the model weights to load. Load the pretrained model")
+    parser.add_argument("-d", "--disable-wandb", action="store_true", help="Disable wandb logging")
 
     args = parser.parse_args()
 
@@ -31,6 +32,9 @@ if __name__ == "__main__":
             exit(1)
     else:
         model = YOLO(GetModelYaml(training_task))  # Initialize model
+
+    if args.disable_wandb:
+        os.environ['WANDB_MODE'] = 'disabled'
 
     model.train(
         task=training_task,


### PR DESCRIPTION
The simple_training.py script initially requires users to enter their wandb credentials and choose whether to enable logging. This preference is then saved and used for future runs. By adding a command-line argument, users can easily disable wandb logging, providing more flexibility for individual runs.

## Test
`python simple_training.py -d`
`python simple_training.py --disable-wandb`