### PR TITLE
Jonghoon/predictive heads

### DIFF
--- a/training_utils/training_utils.py
+++ b/training_utils/training_utils.py
@@ -26,7 +26,8 @@ def PrepareDataset(coco_classes_file, dataset_yaml, training_task):
         f.write("names:\n")
         for i in range(len(classes)):
             f.write(f"  {i}: {classes[i]}\n")
-        if training_task == "pose" or training_task == "pose-contrastive" or training_task == "pose-multiclsheads":
+        if training_task == "pose" or training_task == "pose-contrastive" \
+        or training_task == "pose-multiclsheads" or training_task == "pose-tunablehead":
             f.write("\nkpt_shape: [1, 3]\n")  # enforce keypoint shape to [1, 3] for pose models
             f.write("flip_idx: [0]\n")  # enforce left-right flipping of keypoints
     return
@@ -41,6 +42,8 @@ def GetModelYaml(task):
         return "yolov8n-pose-contrastive.yaml"
     elif task == "pose-multiclsheads":
         return "yolov8n-pose-multiclsheads.yaml"
+    elif task == "pose-tunablehead":
+        return "yolov8n-pose-tunablehead.yaml"
     print(f"Unknown task {task}")
     return None
 

--- a/ultralytics/cfg/__init__.py
+++ b/ultralytics/cfg/__init__.py
@@ -13,23 +13,26 @@ from ultralytics.utils import (ASSETS, DEFAULT_CFG, DEFAULT_CFG_DICT, DEFAULT_CF
 
 # Define valid tasks and modes
 MODES = 'train', 'val', 'predict', 'export', 'track', 'benchmark'
-TASKS = 'detect', 'segment', 'classify', 'pose', 'pose-contrastive', 'pose-multiclsheads'
+TASKS = 'detect', 'segment', 'classify', 'pose', 'pose-contrastive', 'pose-multiclsheads', 'pose-tunablehead'
 TASK2DATA = {'detect': 'coco8.yaml', 'segment': 'coco8-seg.yaml', 'classify': 'imagenet10', 
-             'pose': 'coco8-pose.yaml', 'pose-contrastive': 'coco8-pose.yaml', 'pose-multiclsheads': 'coco8-pose.yaml'}
+             'pose': 'coco8-pose.yaml', 'pose-contrastive': 'coco8-pose.yaml', 
+             'pose-multiclsheads': 'coco8-pose.yaml', 'pose-tunablehead': 'coco8-pose.yaml'}
 TASK2MODEL = {
     'detect': 'yolov8n.pt',
     'segment': 'yolov8n-seg.pt',
     'classify': 'yolov8n-cls.pt',
     'pose': 'yolov8n-pose.pt',
     'pose-contrastive': 'yolov8n-pose-contrastive.pt',
-    'pose-multiclsheads': 'yolov8n-pose-multiclsheads.pt'}
+    'pose-multiclsheads': 'yolov8n-pose-multiclsheads.pt',
+    'pose-tunablehead': 'yolov8n-pose-tunablehead.pt'}
 TASK2METRIC = {
     'detect': 'metrics/mAP50-95(B)',
     'segment': 'metrics/mAP50-95(M)',
     'classify': 'metrics/accuracy_top1',
     'pose': 'metrics/mAP50-95(P)',
     'pose-contrastive': 'metrics/mAP50-95(P)',
-    'pose-multiclsheads': 'metrics/mAP50-95(P)'}
+    'pose-multiclsheads': 'metrics/mAP50-95(P)',
+    'pose-tunablehead': 'metrics/mAP50-95(P)'}
 
 CLI_HELP_MSG = \
     f"""

--- a/ultralytics/cfg/default.yaml
+++ b/ultralytics/cfg/default.yaml
@@ -1,7 +1,7 @@
 # Ultralytics YOLO 🚀, AGPL-3.0 license
 # Default training settings and hyperparameters for medium-augmentation COCO training
 
-task: detect  # (str) YOLO task, i.e. detect, segment, classify, pose, pose-contrastive, pose-multiclsheads
+task: detect  # (str) YOLO task, i.e. detect, segment, classify, pose, pose-contrastive, pose-multiclsheads, pose-tunablehead
 mode: train  # (str) YOLO mode, i.e. train, val, predict, export, track, benchmark
 
 # Train settings -------------------------------------------------------------------------------------------------------

--- a/ultralytics/cfg/models/v8/yolov8-pose-tunablehead.yaml
+++ b/ultralytics/cfg/models/v8/yolov8-pose-tunablehead.yaml
@@ -1,0 +1,47 @@
+# Ultralytics YOLO 🚀, AGPL-3.0 license
+# YOLOv8-pose keypoints/pose estimation model. For Usage examples see https://docs.ultralytics.com/tasks/pose
+
+# Parameters
+nc: 1  # number of classes
+kpt_shape: [17, 3]  # number of keypoints, number of dims (2 for x,y or 3 for x,y,visible)
+scales: # model compound scaling constants, i.e. 'model=yolov8n-pose-tunablehead.yaml' will call yolov8-pose-tunablehead.yaml with scale 'n'
+  # [depth, width, max_channels]
+  n: [0.33, 0.25, 1024]
+  s: [0.33, 0.50, 1024]
+  m: [0.67, 0.75, 768]
+  l: [1.00, 1.00, 512]
+  x: [1.00, 1.25, 512]
+
+# YOLOv8.0n backbone
+backbone:
+  # [from, repeats, module, args]
+  - [-1, 1, Conv, [64, 3, 2]]  # 0-P1/2
+  - [-1, 1, Conv, [128, 3, 2]]  # 1-P2/4
+  - [-1, 3, C2f, [128, True]]
+  - [-1, 1, Conv, [256, 3, 2]]  # 3-P3/8
+  - [-1, 6, C2f, [256, True]]
+  - [-1, 1, Conv, [512, 3, 2]]  # 5-P4/16
+  - [-1, 6, C2f, [512, True]]
+  - [-1, 1, Conv, [1024, 3, 2]]  # 7-P5/32
+  - [-1, 3, C2f, [1024, True]]
+  - [-1, 1, SPPF, [1024, 5]]  # 9
+
+# YOLOv8.0n head
+head:
+  - [-1, 1, nn.Upsample, [None, 2, 'nearest']]
+  - [[-1, 6], 1, Concat, [1]]  # cat backbone P4
+  - [-1, 3, C2f, [512]]  # 12
+
+  - [-1, 1, nn.Upsample, [None, 2, 'nearest']]
+  - [[-1, 4], 1, Concat, [1]]  # cat backbone P3
+  - [-1, 3, C2f, [256]]  # 15 (P3/8-small)
+
+  - [-1, 1, Conv, [256, 3, 2]]
+  - [[-1, 12], 1, Concat, [1]]  # cat head P4
+  - [-1, 3, C2f, [512]]  # 18 (P4/16-medium)
+
+  - [-1, 1, Conv, [512, 3, 2]]
+  - [[-1, 9], 1, Concat, [1]]  # cat head P5
+  - [-1, 3, C2f, [1024]]  # 21 (P5/32-large)
+
+  - [[15, 18, 21], 1, PoseTunableHead, [nc, kpt_shape]]  # Pose(P3, P4, P5)

--- a/ultralytics/data/build.py
+++ b/ultralytics/data/build.py
@@ -90,7 +90,7 @@ def build_yolo_dataset(cfg, img_path, batch, data, mode='train', rect=False, str
         pad=0.0 if mode == 'train' else 0.5,
         prefix=colorstr(f'{mode}: '),
         use_segments=cfg.task == 'segment',
-        use_keypoints=cfg.task in {'pose', 'pose-contrastive', 'pose-multiclsheads'},
+        use_keypoints=cfg.task in {'pose', 'pose-contrastive', 'pose-multiclsheads', 'pose-tunablehead'},
         classes=cfg.classes,
         data=data,
         fraction=cfg.fraction if mode == 'train' else 1.0)

--- a/ultralytics/engine/exporter.py
+++ b/ultralytics/engine/exporter.py
@@ -65,8 +65,8 @@ from ultralytics.cfg import get_cfg
 from ultralytics.data.dataset import YOLODataset
 from ultralytics.data.utils import check_det_dataset
 from ultralytics.nn.autobackend import check_class_names
-from ultralytics.nn.modules import C2f, Detect, RTDETRDecoder, DetectContrastive, DetectMultiClsHeads
-from ultralytics.nn.tasks import DetectionModel, SegmentationModel, PoseContrastiveModel, PoseMultiClsHeadsModel
+from ultralytics.nn.modules import C2f, Detect, RTDETRDecoder, DetectContrastive, DetectMultiClsHeads, DetectTunableHead
+from ultralytics.nn.tasks import DetectionModel, SegmentationModel, PoseContrastiveModel, PoseMultiClsHeadsModel, PoseTunableHeadModel
 from ultralytics.utils import (ARM64, DEFAULT_CFG, LINUX, LOGGER, MACOS, ROOT, WINDOWS, __version__, callbacks,
                                colorstr, get_default_args, yaml_save)
 from ultralytics.utils.checks import check_imgsz, check_requirements, check_version
@@ -203,7 +203,7 @@ class Exporter:
         model.float()
         model = model.fuse()
         for m in model.modules():
-            if isinstance(m, (Detect, DetectContrastive, DetectMultiClsHeads, RTDETRDecoder)):  # Segment and Pose use Detect base class
+            if isinstance(m, (Detect, DetectContrastive, DetectMultiClsHeads, DetectTunableHead, RTDETRDecoder)):  # Segment and Pose use Detect base class
                 m.dynamic = self.args.dynamic
                 m.export = True
                 m.format = self.args.format
@@ -213,8 +213,9 @@ class Exporter:
 
         y = None
         for _ in range(2):
-            # y = model(im)  # dry runs
-            y = model(im, image_features)  # dry runs
+            if isinstance(m, PoseTunableHeadModel):
+                y = model(im, image_features)  # take one hot vector of image features as extra input
+            y = model(im)  # dry runs
         if self.args.half and (engine or onnx) and self.device.type != 'cpu':
             # im, model = im.half(), model.half()  # to FP16
             im, image_features, model = im.half(), image_features.half(), model.half()  # to FP16
@@ -245,7 +246,7 @@ class Exporter:
             'batch': self.args.batch,
             'imgsz': self.imgsz,
             'names': model.names}  # model metadata
-        if model.task in {'pose', 'pose-contrastive', 'pose-multiclsheads'}:
+        if model.task in {'pose', 'pose-contrastive', 'pose-multiclsheads', 'pose-tunablehead'}:
             self.metadata['kpt_shape'] = model.model[-1].kpt_shape
 
         LOGGER.info(f"\n{colorstr('PyTorch:')} starting from '{file}' with input shape {tuple(im.shape)} BCHW and "
@@ -327,18 +328,26 @@ class Exporter:
         LOGGER.info(f'\n{prefix} starting export with onnx {onnx.__version__} opset {opset_version}...')
         f = str(self.file.with_suffix('.onnx'))
 
+        # default input name and input tensor
+        input_names = ['images']  # input node names
+        inputs = self.im.cpu() if self.args.dynamic else self.im  # input image tensor (dynamic input only supports cpu)
+
         if isinstance(self.model, SegmentationModel):
             output_names = ['output0', 'output1']
         elif isinstance(self.model, PoseContrastiveModel):
             print('Exporting pose contrastive model')
             output_names = ['output0', 'embeddings']
+        elif isinstance(self.model, PoseTunableHeadModel):
+            input_names = ['images', 'image_features']
+            output_names = ['output0']
+            inputs = (self.im.cpu() if self.args.dynamic else self.im, 
+                      self.image_features.cpu() if self.args.dynamic else self.image_features)
         else:
             output_names = ['output0']
+        
         dynamic = self.args.dynamic
         if dynamic:
-            # dynamic = {'images': {0: 'batch', 2: 'height', 3: 'width'}}  # shape(1,3,640,640)
-            dynamic = {'images': {0: 'batch', 2: 'height', 3: 'width'},  # shape(1,3,640,640)
-                        'image_features': {0: 'batch', 1: 'feature_dim'}}  # shape(1, nc//2)
+            dynamic = {'images': {0: 'batch', 2: 'height', 3: 'width'}}  # shape(1,3,640,640)
             if isinstance(self.model, SegmentationModel):
                 dynamic['output0'] = {0: 'batch', 2: 'anchors'}  # shape(1, 116, 8400)
                 dynamic['output1'] = {0: 'batch', 2: 'mask_height', 3: 'mask_width'}  # shape(1,32,160,160)
@@ -347,19 +356,15 @@ class Exporter:
                 dynamic['embeddings'] = {0: 'batch', 2: 'anchors'}
             elif isinstance(self.model, DetectionModel):
                 dynamic['output0'] = {0: 'batch', 2: 'anchors'}  # shape(1, 84, 8400)
-        # TODO: make if condition for new task (inputting extra features as extra input to cls head)
 
         torch.onnx.export(
             self.model.cpu() if dynamic else self.model,  # dynamic=True only compatible with cpu
-            # self.im.cpu() if dynamic else self.im,
-            (self.im.cpu() if dynamic else self.im, 
-             self.image_features.cpu() if dynamic else self.image_features),
+            inputs,
             f,
             verbose=False,
             opset_version=opset_version,
             do_constant_folding=True,  # WARNING: DNN inference with torch>=1.12 may require do_constant_folding=False
-            # input_names=['images'],
-            input_names=['images', 'image_features'],
+            input_names=input_names,
             output_names=output_names,
             dynamic_axes=dynamic or None)
 

--- a/ultralytics/engine/trainer.py
+++ b/ultralytics/engine/trainer.py
@@ -395,7 +395,47 @@ class BaseTrainer:
                 # Forward
                 with torch.cuda.amp.autocast(self.amp):
                     batch = self.preprocess_batch(batch)
-                    self.loss, self.loss_items = self.model(batch)
+
+                    # convert gt labels to one hot field vector 
+                    # and DO THIS FOR THE DEDICATED TASK CLASS by creating a new class in pose/trainer.py and overwriting _do_train()
+                    x_img, x_cls, x_bbox, x_batchidx = batch['img'], batch['cls'], batch['bboxes'], batch['batch_idx']
+                    imgsz, device = x_img.shape[2:], x_img.device
+                    n_img_features = self.model.module.nc // 2
+
+                    # process gt cls labels
+                    from ultralytics.utils.ops import xywh2xyxy
+                    def preprocess(targets, batch_size, scale_tensor, device):
+                        """Preprocesses the target counts and matches with the input batch size to output a tensor."""
+                        if targets.shape[0] == 0:
+                            out = torch.zeros(batch_size, 0, 5, device=device)
+                        else:
+                            i = targets[:, 0]  # image index
+                            _, counts = i.unique(return_counts=True)
+                            counts = counts.to(dtype=torch.int32)
+                            out = torch.zeros(batch_size, counts.max(), 5, device=device)
+                            for j in range(batch_size):
+                                matches = i == j
+                                n = matches.sum()
+                                if n:
+                                    out[j, :n] = targets[matches, 1:]
+                            out[..., 1:5] = xywh2xyxy(out[..., 1:5].mul_(scale_tensor))  #TODO: remove 1:5 for bbox, just keep 0 for cls
+                        return out
+                    batch_size = x_img.shape[0]
+                    targets = torch.cat((x_batchidx.view(-1,1), x_cls.view(-1, 1), x_bbox), 1)
+                    scale_tensor = torch.tensor([imgsz[1], imgsz[0], imgsz[1], imgsz[0]], device=device)
+                    targets = preprocess(targets.to(device), batch_size, scale_tensor=scale_tensor, device=device)
+                    gt_labels, _ = targets.split((1, 4), 2)  # cls gt labels (B, n_gt_labels, 1)
+                    
+                    # create one-hot vectors for image features (e.g., image source) using gt labels
+                    gt_labels = gt_labels.squeeze(-1).long()  # (B, n_gt_labels)
+                    self.img_features = torch.zeros(gt_labels.shape[0], n_img_features)  # initialize and stack B number of source vectors (B, nc//2)
+                    if gt_labels.shape[1] > 0:  # if at least one image in the batch has gt labels
+                        img_features_indices = gt_labels[:, 0] // 2  # infer source from any gt label for all inputs in batch (B)
+                        # Note: if gt_label[0]=0 and it means no labels, not class idx 0, then this will be handled during loss computation
+                        self.img_features[torch.arange(gt_labels.shape[0]), img_features_indices] = 1  # assign 1 to source index for each source vector
+
+                    # self.loss, self.loss_items = self.model(batch)
+                    self.loss, self.loss_items = self.model(batch, self.img_features)
                     if RANK != -1:
                         self.loss *= world_size
                     self.tloss = (self.tloss * i + self.loss_items) / (i + 1) if self.tloss is not None \

--- a/ultralytics/engine/validator.py
+++ b/ultralytics/engine/validator.py
@@ -149,7 +149,9 @@ class BaseValidator:
             self.dataloader = self.dataloader or self.get_dataloader(self.data.get(self.args.split), self.args.batch)
 
             model.eval()
-            model.warmup(imgsz=(1 if pt else self.args.batch, 3, imgsz, imgsz))  # warmup
+            # model.warmup(imgsz=(1 if pt else self.args.batch, 3, imgsz, imgsz))  # warmup
+            img_features_sz = (1 if pt else self.args.batch, self.nc // 2)
+            model.warmup(imgsz=(1 if pt else self.args.batch, 3, imgsz, imgsz), img_features_sz=img_features_sz)  # warmup
 
         self.run_callbacks('on_val_start')
         dt = Profile(), Profile(), Profile(), Profile()
@@ -159,18 +161,61 @@ class BaseValidator:
         for batch_i, batch in enumerate(bar):
             self.run_callbacks('on_val_batch_start')
             self.batch_i = batch_i
+
+            # convert gt labels to one hot field vector 
+            # and DO THIS FOR THE DEDICATED TASK CLASS by creating a new class in pose/trainer.py and overwriting _do_train()
+            x_img, x_cls, x_bbox, x_batchidx = batch['img'], batch['cls'], batch['bboxes'], batch['batch_idx']
+            imgsz, device = x_img.shape[2:], x_img.device
+            n_img_features = self.nc // 2
+
+            # process gt cls labels
+            from ultralytics.utils.ops import xywh2xyxy
+            def preprocess(targets, batch_size, scale_tensor, device):
+                """Preprocesses the target counts and matches with the input batch size to output a tensor."""
+                if targets.shape[0] == 0:
+                    out = torch.zeros(batch_size, 0, 5, device=device)
+                else:
+                    i = targets[:, 0]  # image index
+                    _, counts = i.unique(return_counts=True)
+                    counts = counts.to(dtype=torch.int32)
+                    out = torch.zeros(batch_size, counts.max(), 5, device=device)
+                    for j in range(batch_size):
+                        matches = i == j
+                        n = matches.sum()
+                        if n:
+                            out[j, :n] = targets[matches, 1:]
+                    out[..., 1:5] = xywh2xyxy(out[..., 1:5].mul_(scale_tensor))
+                return out
+            batch_size = x_img.shape[0]
+            targets = torch.cat((x_batchidx.view(-1,1), x_cls.view(-1, 1), x_bbox), 1)
+            scale_tensor = torch.tensor([imgsz[1], imgsz[0], imgsz[1], imgsz[0]], device=device)
+            targets = preprocess(targets.to(device), batch_size, scale_tensor=scale_tensor, device=device)
+            gt_labels, _ = targets.split((1, 4), 2)  # cls gt labels (B, n_gt_labels, 1)
+            
+            # create one-hot vectors for image features (e.g., image source) using gt labels
+            gt_labels = gt_labels.squeeze(-1).long()  # (B, n_gt_labels)
+            self.img_features = torch.zeros(gt_labels.shape[0], n_img_features)  # initialize and stack B number of source vectors (B, nc//2)
+            if gt_labels.shape[1] > 0:  # if at least one image has gt labels within the batch
+                img_features_indices = gt_labels[:, 0] // 2  # infer source from any gt label for all inputs in batch (B)
+                self.img_features[torch.arange(gt_labels.shape[0]), img_features_indices] = 1  # assign 1 to source index for each source vector
+
+            # add img_features to batch
+            self.img_features = self.img_features.half() if self.args.half else self.img_features.float()
+
             # Preprocess
             with dt[0]:
                 batch = self.preprocess(batch)
 
             # Inference
             with dt[1]:
-                preds = model(batch['img'], augment=augment)
+                # preds = model(batch['img'], augment=augment)
+                preds = model(batch['img'], self.img_features, augment=augment)
 
             # Loss
             with dt[2]:
                 if self.training:
-                    self.loss += model.loss(batch, preds)[1]
+                    # self.loss += model.loss(batch, preds)[1]
+                    self.loss += model.loss(batch, self.img_features, preds)[1]
 
             # Postprocess
             with dt[3]:

--- a/ultralytics/models/yolo/__init__.py
+++ b/ultralytics/models/yolo/__init__.py
@@ -4,4 +4,4 @@ from ultralytics.models.yolo import classify, detect, pose, segment
 
 from .model import YOLO
 
-__all__ = 'classify', 'segment', 'detect', 'pose', 'pose-contrastive', 'pose-multiclsheads', 'YOLO'
+__all__ = 'classify', 'segment', 'detect', 'pose', 'pose-contrastive', 'pose-multiclsheads', 'pose-tunablehead', 'YOLO'

--- a/ultralytics/models/yolo/model.py
+++ b/ultralytics/models/yolo/model.py
@@ -3,7 +3,7 @@
 from ultralytics.engine.model import Model
 from ultralytics.models import yolo  # noqa
 from ultralytics.nn.tasks import (ClassificationModel, DetectionModel, PoseModel, PoseContrastiveModel, 
-                                  PoseMultiClsHeadsModel, SegmentationModel)
+                                  PoseMultiClsHeadsModel, PoseTunableHeadModel, SegmentationModel)
 
 
 class YOLO(Model):
@@ -41,6 +41,11 @@ class YOLO(Model):
             'pose-multiclsheads': {
                 'model': PoseMultiClsHeadsModel,
                 'trainer': yolo.pose.PoseMultiClsHeadsTrainer,
+                'validator': yolo.pose.PoseValidator,
+                'predictor': yolo.pose.PosePredictor, },
+            'pose-tunablehead': {
+                'model': PoseTunableHeadModel,
+                'trainer': yolo.pose.PoseTunableHeadTrainer,
                 'validator': yolo.pose.PoseValidator,
                 'predictor': yolo.pose.PosePredictor, },
             }

--- a/ultralytics/models/yolo/pose/__init__.py
+++ b/ultralytics/models/yolo/pose/__init__.py
@@ -1,7 +1,8 @@
 # Ultralytics YOLO 🚀, AGPL-3.0 license
 
 from .predict import PosePredictor
-from .train import PoseTrainer, PoseContrastiveTrainer, PoseMultiClsHeadsTrainer
+from .train import PoseTrainer, PoseContrastiveTrainer, PoseMultiClsHeadsTrainer, PoseTunableHeadTrainer
 from .val import PoseValidator
 
-__all__ = 'PoseTrainer', 'PoseContrastiveTrainer', 'PoseMultiClsHeadsTrainer', 'PoseValidator', 'PosePredictor'
+__all__ = 'PoseTrainer', 'PoseContrastiveTrainer', 'PoseMultiClsHeadsTrainer', 'PoseTunableHeadTrainer', \
+    'PoseValidator', 'PosePredictor'

--- a/ultralytics/models/yolo/pose/train.py
+++ b/ultralytics/models/yolo/pose/train.py
@@ -3,7 +3,7 @@
 from copy import copy
 
 from ultralytics.models import yolo
-from ultralytics.nn.tasks import PoseModel, PoseContrastiveModel, PoseMultiClsHeadsModel
+from ultralytics.nn.tasks import PoseModel, PoseContrastiveModel, PoseMultiClsHeadsModel, PoseTunableHeadModel
 from ultralytics.utils import DEFAULT_CFG, LOGGER
 from ultralytics.utils.plotting import plot_images, plot_results
 
@@ -137,3 +137,37 @@ class PoseMultiClsHeadsTrainer(PoseTrainer):
             model.load(weights)
 
         return model
+    
+
+class PoseTunableHeadTrainer(PoseTrainer):
+    """
+    A class extending the DetectionTrainer class for training based on a pose model.
+
+    Example:
+        ```python
+        from ultralytics.models.yolo.pose import PoseTunableHeadTrainer
+
+        args = dict(model='yolov8n-pose-tunablehead.pt', data='coco8-pose.yaml', epochs=3)
+        trainer = PoseTunableHeadTrainer(overrides=args)
+        trainer.train()
+        ```
+    """
+    def __init__(self, cfg=DEFAULT_CFG, overrides=None, _callbacks=None):
+        """Initialize a PoseTunableHeadTrainer object with specified configurations and overrides."""
+        if overrides is None:
+            overrides = {}
+        overrides['task'] = 'pose-tunablehead'
+        super().__init__(cfg, overrides, _callbacks)
+
+        if isinstance(self.args.device, str) and self.args.device.lower() == 'mps':
+            LOGGER.warning("WARNING ⚠️ Apple MPS known Pose bug. Recommend 'device=cpu' for Pose models. "
+                           'See https://github.com/ultralytics/ultralytics/issues/4031.')
+            
+    def get_model(self, cfg=None, weights=None, verbose=True):
+        """Get pose estimation model with specified configuration and weights."""
+        model = PoseTunableHeadModel(cfg, ch=3, nc=self.data['nc'], data_kpt_shape=self.data['kpt_shape'], verbose=verbose)
+        if weights:
+            model.load(weights)
+
+        return model
+    

--- a/ultralytics/nn/autobackend.py
+++ b/ultralytics/nn/autobackend.py
@@ -325,8 +325,7 @@ class AutoBackend(nn.Module):
 
         self.__dict__.update(locals())  # assign all variables to self
 
-    # def forward(self, im, augment=False, visualize=False):
-    def forward(self, im, img_features, augment=False, visualize=False):
+    def forward(self, im, augment=False, visualize=False):
         """
         Runs inference on the YOLOv8 MultiBackend model.
 
@@ -338,20 +337,10 @@ class AutoBackend(nn.Module):
         Returns:
             (tuple): Tuple containing the raw output tensor, and processed output for visualization (if visualize=True)
         """
-        # b, ch, h, w = im.shape  # batch, channel, height, width
-        # if self.fp16 and im.dtype != torch.float16:
-        #     im = im.half()  # to FP16
-        # if self.nhwc:
-        #     im = im.permute(0, 2, 3, 1)  # torch BCHW to numpy BHWC shape(1,320,192,3)
-        if isinstance(im, tuple):
-            b, ch, h, w = im[0].shape  # batch, channel, height, width
-        else:
-            b, ch, h, w = im.shape
+        b, ch, h, w = im.shape  # batch, channels, height, width
 
         if self.pt or self.nn_module:  # PyTorch
-            # y = self.model(im, augment=augment, visualize=visualize) if augment or visualize else self.model(im)
-            y = self.model(im, img_features, augment=augment, visualize=visualize) \
-                if augment or visualize else self.model(im, img_features)
+            y = self.model(im, augment=augment, visualize=visualize) if augment or visualize else self.model(im)
         elif self.jit:  # TorchScript
             y = self.model(im)
         elif self.dnn:  # ONNX OpenCV DNN
@@ -470,23 +459,7 @@ class AutoBackend(nn.Module):
         """
         return torch.tensor(x).to(self.device) if isinstance(x, np.ndarray) else x
 
-    # def warmup(self, imgsz=(1, 3, 640, 640)):
-    #     """
-    #     Warm up the model by running one forward pass with a dummy input.
-
-    #     Args:
-    #         imgsz (tuple): The shape of the dummy input tensor in the format (batch_size, channels, height, width)
-
-    #     Returns:
-    #         (None): This method runs the forward pass and don't return any value
-    #     """
-    #     warmup_types = self.pt, self.jit, self.onnx, self.engine, self.saved_model, self.pb, self.triton, self.nn_module
-    #     if any(warmup_types) and (self.device.type != 'cpu' or self.triton):
-    #         im = torch.empty(*imgsz, dtype=torch.half if self.fp16 else torch.float, device=self.device)  # input
-    #         for _ in range(2 if self.jit else 1):  #
-    #             self.forward(im)  # warmup
-
-    def warmup(self, imgsz=(1, 3, 640, 640), img_features_sz=(1,1)):  # experimental
+    def warmup(self, imgsz=(1, 3, 640, 640)):
         """
         Warm up the model by running one forward pass with a dummy input.
 
@@ -499,10 +472,8 @@ class AutoBackend(nn.Module):
         warmup_types = self.pt, self.jit, self.onnx, self.engine, self.saved_model, self.pb, self.triton, self.nn_module
         if any(warmup_types) and (self.device.type != 'cpu' or self.triton):
             im = torch.empty(*imgsz, dtype=torch.half if self.fp16 else torch.float, device=self.device)  # input
-            img_features = torch.empty(*img_features_sz, dtype=torch.half if self.fp16 
-                                       else torch.float, device=self.device)  # extra input
             for _ in range(2 if self.jit else 1):  #
-                self.forward(im, img_features)  # warmup
+                self.forward(im)  # warmup
 
     @staticmethod
     def _apply_default_class_names(data):

--- a/ultralytics/nn/modules/__init__.py
+++ b/ultralytics/nn/modules/__init__.py
@@ -21,7 +21,8 @@ from .block import (C1, C2, C3, C3TR, DFL, SPP, SPPF, Bottleneck, BottleneckCSP,
                     HGBlock, HGStem, Proto, RepC3)
 from .conv import (CBAM, ChannelAttention, Concat, Conv, Conv2, ConvTranspose, DWConv, DWConvTranspose2d, Focus,
                    GhostConv, LightConv, RepConv, SpatialAttention)
-from .head import (Classify, Detect, DetectContrastive, DetectMultiClsHeads, Pose, PoseContrastive, PoseMultiClsHeads, 
+from .head import (Classify, Detect, DetectContrastive, DetectMultiClsHeads, DetectTunableHead,
+                   Pose, PoseContrastive, PoseMultiClsHeads, PoseTunableHead,
                    RTDETRDecoder, Segment)
 from .transformer import (AIFI, MLP, DeformableTransformerDecoder, DeformableTransformerDecoderLayer, LayerNorm2d,
                           MLPBlock, MSDeformAttn, TransformerBlock, TransformerEncoderLayer, TransformerLayer)
@@ -30,5 +31,5 @@ __all__ = ('Conv', 'Conv2', 'LightConv', 'RepConv', 'DWConv', 'DWConvTranspose2d
            'GhostConv', 'ChannelAttention', 'SpatialAttention', 'CBAM', 'Concat', 'TransformerLayer',
            'TransformerBlock', 'MLPBlock', 'LayerNorm2d', 'DFL', 'HGBlock', 'HGStem', 'SPP', 'SPPF', 'C1', 'C2', 'C3',
            'C2f', 'C3x', 'C3TR', 'C3Ghost', 'GhostBottleneck', 'Bottleneck', 'BottleneckCSP', 'Proto', 'Detect', 'DetectContrastive', 
-           'DetectMultiClsHeads', 'Segment', 'Pose', 'PoseContrastive', 'PoseMultiClsHeads', 'Classify', 'TransformerEncoderLayer', 
+           'DetectMultiClsHeads', 'DetectTunableHead', 'Segment', 'Pose', 'PoseContrastive', 'PoseMultiClsHeads', 'PoseTunableHead', 'Classify', 'TransformerEncoderLayer', 
            'RepC3', 'RTDETRDecoder', 'AIFI', 'DeformableTransformerDecoder', 'DeformableTransformerDecoderLayer', 'MSDeformAttn', 'MLP')

--- a/ultralytics/nn/modules/head.py
+++ b/ultralytics/nn/modules/head.py
@@ -15,70 +15,70 @@ from .transformer import MLP, DeformableTransformerDecoder, DeformableTransforme
 from .utils import bias_init_with_prob, linear_init_
 # from ultralytics.utils.ops import xywh2xyxy
 
-__all__ = ('Detect', 'DetectContrastive', 'DetectMultiClsHeads', 'Segment', 
-           'Pose', 'PoseContrastive', 'PoseMultiClsHeads', 'Classify', 'RTDETRDecoder')
+__all__ = ('Detect', 'DetectContrastive', 'DetectMultiClsHeads', 'DetectTunableHead', 'Segment', 
+           'Pose', 'PoseContrastive', 'PoseMultiClsHeads', 'PoseTunableHead', 'Classify', 'RTDETRDecoder')
 
-# class Detect(nn.Module):
-#     """YOLOv8 Detect head for detection models."""
-#     dynamic = False  # force grid reconstruction
-#     export = False  # export mode
-#     shape = None
-#     anchors = torch.empty(0)  # init
-#     strides = torch.empty(0)  # init
+class Detect(nn.Module):
+    """YOLOv8 Detect head for detection models."""
+    dynamic = False  # force grid reconstruction
+    export = False  # export mode
+    shape = None
+    anchors = torch.empty(0)  # init
+    strides = torch.empty(0)  # init
 
-#     def __init__(self, nc=80, ch=()):
-#         """Initializes the YOLOv8 detection layer with specified number of classes and channels."""
-#         super().__init__()
-#         self.nc = nc  # number of classes
-#         self.nl = len(ch)  # number of detection layers
-#         self.reg_max = 16  # DFL channels (ch[0] // 16 to scale 4/8/12/16/20 for n/s/m/l/x)
-#         self.no = nc + self.reg_max * 4  # number of outputs per anchor
-#         self.stride = torch.zeros(self.nl)  # strides computed during build
-#         c2, c3 = max(16, ch[0] // 4, self.reg_max * 4), max(ch[0], min(self.nc, 100))  # channels
-#         self.cv2 = nn.ModuleList(
-#             nn.Sequential(Conv(x, c2, 3), Conv(c2, c2, 3), nn.Conv2d(c2, 4 * self.reg_max, 1)) for x in ch)
-#         self.cv3 = nn.ModuleList(nn.Sequential(Conv(x, c3, 3), Conv(c3, c3, 3), nn.Conv2d(c3, self.nc, 1)) for x in ch)
-#         self.dfl = DFL(self.reg_max) if self.reg_max > 1 else nn.Identity()
+    def __init__(self, nc=80, ch=()):
+        """Initializes the YOLOv8 detection layer with specified number of classes and channels."""
+        super().__init__()
+        self.nc = nc  # number of classes
+        self.nl = len(ch)  # number of detection layers
+        self.reg_max = 16  # DFL channels (ch[0] // 16 to scale 4/8/12/16/20 for n/s/m/l/x)
+        self.no = nc + self.reg_max * 4  # number of outputs per anchor
+        self.stride = torch.zeros(self.nl)  # strides computed during build
+        c2, c3 = max(16, ch[0] // 4, self.reg_max * 4), max(ch[0], min(self.nc, 100))  # channels
+        self.cv2 = nn.ModuleList(
+            nn.Sequential(Conv(x, c2, 3), Conv(c2, c2, 3), nn.Conv2d(c2, 4 * self.reg_max, 1)) for x in ch)
+        self.cv3 = nn.ModuleList(nn.Sequential(Conv(x, c3, 3), Conv(c3, c3, 3), nn.Conv2d(c3, self.nc, 1)) for x in ch)
+        self.dfl = DFL(self.reg_max) if self.reg_max > 1 else nn.Identity()
 
-#     def forward(self, x):
-#         """Concatenates and returns predicted bounding boxes and class probabilities."""
-#         shape = x[0].shape  # BCHW
-#         for i in range(self.nl):  # per detection scale
-#             x[i] = torch.cat((self.cv2[i](x[i]), self.cv3[i](x[i])), 1)
-#         if self.training:
-#             return x
-#         elif self.dynamic or self.shape != shape:
-#             self.anchors, self.strides = (x.transpose(0, 1) for x in make_anchors(x, self.stride, 0.5))
-#             self.shape = shape
+    def forward(self, x):
+        """Concatenates and returns predicted bounding boxes and class probabilities."""
+        shape = x[0].shape  # BCHW
+        for i in range(self.nl):  # per detection scale
+            x[i] = torch.cat((self.cv2[i](x[i]), self.cv3[i](x[i])), 1)
+        if self.training:
+            return x
+        elif self.dynamic or self.shape != shape:
+            self.anchors, self.strides = (x.transpose(0, 1) for x in make_anchors(x, self.stride, 0.5))
+            self.shape = shape
 
-#         x_cat = torch.cat([xi.view(shape[0], self.no, -1) for xi in x], 2)
-#         if self.export and self.format in ('saved_model', 'pb', 'tflite', 'edgetpu', 'tfjs'):  # avoid TF FlexSplitV ops
-#             box = x_cat[:, :self.reg_max * 4]
-#             cls = x_cat[:, self.reg_max * 4:]
-#         else:
-#             box, cls = x_cat.split((self.reg_max * 4, self.nc), 1)
-#         dbox = dist2bbox(self.dfl(box), self.anchors.unsqueeze(0), xywh=True, dim=1) * self.strides
+        x_cat = torch.cat([xi.view(shape[0], self.no, -1) for xi in x], 2)
+        if self.export and self.format in ('saved_model', 'pb', 'tflite', 'edgetpu', 'tfjs'):  # avoid TF FlexSplitV ops
+            box = x_cat[:, :self.reg_max * 4]
+            cls = x_cat[:, self.reg_max * 4:]
+        else:
+            box, cls = x_cat.split((self.reg_max * 4, self.nc), 1)
+        dbox = dist2bbox(self.dfl(box), self.anchors.unsqueeze(0), xywh=True, dim=1) * self.strides
 
-#         if self.export and self.format in ('tflite', 'edgetpu'):
-#             # Normalize xywh with image size to mitigate quantization error of TFLite integer models as done in YOLOv5:
-#             # https://github.com/ultralytics/yolov5/blob/0c8de3fca4a702f8ff5c435e67f378d1fce70243/models/tf.py#L307-L309
-#             # See this PR for details: https://github.com/ultralytics/ultralytics/pull/1695
-#             img_h = shape[2] * self.stride[0]
-#             img_w = shape[3] * self.stride[0]
-#             img_size = torch.tensor([img_w, img_h, img_w, img_h], device=dbox.device).reshape(1, 4, 1)
-#             dbox /= img_size
+        if self.export and self.format in ('tflite', 'edgetpu'):
+            # Normalize xywh with image size to mitigate quantization error of TFLite integer models as done in YOLOv5:
+            # https://github.com/ultralytics/yolov5/blob/0c8de3fca4a702f8ff5c435e67f378d1fce70243/models/tf.py#L307-L309
+            # See this PR for details: https://github.com/ultralytics/ultralytics/pull/1695
+            img_h = shape[2] * self.stride[0]
+            img_w = shape[3] * self.stride[0]
+            img_size = torch.tensor([img_w, img_h, img_w, img_h], device=dbox.device).reshape(1, 4, 1)
+            dbox /= img_size
 
-#         y = torch.cat((dbox, cls.sigmoid()), 1)
-#         return y if self.export else (y, x)
+        y = torch.cat((dbox, cls.sigmoid()), 1)
+        return y if self.export else (y, x)
 
-#     def bias_init(self):
-#         """Initialize Detect() biases, WARNING: requires stride availability."""
-#         m = self  # self.model[-1]  # Detect() module
-#         # cf = torch.bincount(torch.tensor(np.concatenate(dataset.labels, 0)[:, 0]).long(), minlength=nc) + 1
-#         # ncf = math.log(0.6 / (m.nc - 0.999999)) if cf is None else torch.log(cf / cf.sum())  # nominal class frequency
-#         for a, b, s in zip(m.cv2, m.cv3, m.stride):  # from
-#             a[-1].bias.data[:] = 1.0  # box
-#             b[-1].bias.data[:m.nc] = math.log(5 / m.nc / (640 / s) ** 2)  # cls (.01 objects, 80 classes, 640 img)
+    def bias_init(self):
+        """Initialize Detect() biases, WARNING: requires stride availability."""
+        m = self  # self.model[-1]  # Detect() module
+        # cf = torch.bincount(torch.tensor(np.concatenate(dataset.labels, 0)[:, 0]).long(), minlength=nc) + 1
+        # ncf = math.log(0.6 / (m.nc - 0.999999)) if cf is None else torch.log(cf / cf.sum())  # nominal class frequency
+        for a, b, s in zip(m.cv2, m.cv3, m.stride):  # from
+            a[-1].bias.data[:] = 1.0  # box
+            b[-1].bias.data[:m.nc] = math.log(5 / m.nc / (640 / s) ** 2)  # cls (.01 objects, 80 classes, 640 img)
 
 
 class DetectContrastive(nn.Module):
@@ -248,8 +248,8 @@ class DetectMultiClsHeads(nn.Module):
                 b.bias.data[:] = math.log(5 / h_size / (640 / s) ** 2)
 
 
-class Detect(nn.Module):  # experimental
-    """YOLOv8 Detect head for detection models with a switchable classification head based on source information input"""
+class DetectTunableHead(nn.Module):
+    """YOLOv8 Detect head for detection models with a tunable classification head based on extra input features"""
     dynamic = False  # force grid reconstruction
     export = False  # export mode
     shape = None
@@ -345,48 +345,7 @@ class Segment(Detect):
         return (torch.cat([x, mc], 1), p) if self.export else (torch.cat([x[0], mc], 1), (x[1], mc, p))
     
 
-# class Pose(Detect):
-#     """YOLOv8 Pose head for keypoints models."""
-
-#     def __init__(self, nc=80, kpt_shape=(17, 3), ch=()):
-#         """Initialize YOLO network with default parameters and Convolutional Layers."""
-#         super().__init__(nc, ch)
-#         self.kpt_shape = kpt_shape  # number of keypoints, number of dims (2 for x,y or 3 for x,y,visible)
-#         self.nk = kpt_shape[0] * kpt_shape[1]  # number of keypoints total
-#         self.detect = Detect.forward
-
-#         c4 = max(ch[0] // 4, self.nk)
-#         self.cv4 = nn.ModuleList(nn.Sequential(Conv(x, c4, 3), Conv(c4, c4, 3), nn.Conv2d(c4, self.nk, 1)) for x in ch)
-
-#     def forward(self, x):
-#         """Perform forward pass through YOLO model and return predictions."""
-#         bs = x[0].shape[0]  # batch size
-#         kpt = torch.cat([self.cv4[i](x[i]).view(bs, self.nk, -1) for i in range(self.nl)], -1)  # (bs, 17*3, h*w)
-#         x = self.detect(self, x)
-#         if self.training:
-#             return x, kpt
-#         pred_kpt = self.kpts_decode(bs, kpt)
-#         return torch.cat([x, pred_kpt], 1) if self.export else (torch.cat([x[0], pred_kpt], 1), (x[1], kpt))
-
-#     def kpts_decode(self, bs, kpts):
-#         """Decodes keypoints."""
-#         ndim = self.kpt_shape[1]
-#         if self.export:  # required for TFLite export to avoid 'PLACEHOLDER_FOR_GREATER_OP_CODES' bug
-#             y = kpts.view(bs, *self.kpt_shape, -1)
-#             a = (y[:, :, :2] * 2.0 + (self.anchors - 0.5)) * self.strides
-#             if ndim == 3:
-#                 a = torch.cat((a, y[:, :, 2:3].sigmoid()), 2)
-#             return a.view(bs, self.nk, -1)
-#         else:
-#             y = kpts.clone()
-#             if ndim == 3:
-#                 y[:, 2::3].sigmoid_()  # inplace sigmoid
-#             y[:, 0::ndim] = (y[:, 0::ndim] * 2.0 + (self.anchors[0] - 0.5)) * self.strides
-#             y[:, 1::ndim] = (y[:, 1::ndim] * 2.0 + (self.anchors[1] - 0.5)) * self.strides
-#             return y
-    
-
-class Pose(Detect):  # experimental
+class Pose(Detect):
     """YOLOv8 Pose head for keypoints models."""
 
     def __init__(self, nc=80, kpt_shape=(17, 3), ch=()):
@@ -399,19 +358,60 @@ class Pose(Detect):  # experimental
         c4 = max(ch[0] // 4, self.nk)
         self.cv4 = nn.ModuleList(nn.Sequential(Conv(x, c4, 3), Conv(c4, c4, 3), nn.Conv2d(c4, self.nk, 1)) for x in ch)
 
+    def forward(self, x):
+        """Perform forward pass through YOLO model and return predictions."""
+        bs = x[0].shape[0]  # batch size
+        kpt = torch.cat([self.cv4[i](x[i]).view(bs, self.nk, -1) for i in range(self.nl)], -1)  # (bs, 17*3, h*w)
+        x = self.detect(self, x)
+        if self.training:
+            return x, kpt
+        pred_kpt = self.kpts_decode(bs, kpt)
+        return torch.cat([x, pred_kpt], 1) if self.export else (torch.cat([x[0], pred_kpt], 1), (x[1], kpt))
+
+    def kpts_decode(self, bs, kpts):
+        """Decodes keypoints."""
+        ndim = self.kpt_shape[1]
+        if self.export:  # required for TFLite export to avoid 'PLACEHOLDER_FOR_GREATER_OP_CODES' bug
+            y = kpts.view(bs, *self.kpt_shape, -1)
+            a = (y[:, :, :2] * 2.0 + (self.anchors - 0.5)) * self.strides
+            if ndim == 3:
+                a = torch.cat((a, y[:, :, 2:3].sigmoid()), 2)
+            return a.view(bs, self.nk, -1)
+        else:
+            y = kpts.clone()
+            if ndim == 3:
+                y[:, 2::3].sigmoid_()  # inplace sigmoid
+            y[:, 0::ndim] = (y[:, 0::ndim] * 2.0 + (self.anchors[0] - 0.5)) * self.strides
+            y[:, 1::ndim] = (y[:, 1::ndim] * 2.0 + (self.anchors[1] - 0.5)) * self.strides
+            return y
+    
+
+class PoseTunableHead(DetectTunableHead):
+    """YOLOv8 Pose head for keypoints models with a tunable classification head based on extra input features."""
+
+    def __init__(self, nc=80, kpt_shape=(17, 3), ch=()):
+        """Initialize YOLO network with default parameters and Convolutional Layers."""
+        super().__init__(nc, ch)
+        self.kpt_shape = kpt_shape  # number of keypoints, number of dims (2 for x,y or 3 for x,y,visible)
+        self.nk = kpt_shape[0] * kpt_shape[1]  # number of keypoints total
+        self.detect = DetectTunableHead.forward
+
+        c4 = max(ch[0] // 4, self.nk)
+        self.cv4 = nn.ModuleList(nn.Sequential(Conv(x, c4, 3), Conv(c4, c4, 3), nn.Conv2d(c4, self.nk, 1)) for x in ch)
+
     def forward(self, x, x_features):
         """Perform forward pass through YOLO model and return predictions."""
         bs = x[0].shape[0]  # batch size
         kpt = torch.cat([self.cv4[i](x[i]).view(bs, self.nk, -1) for i in range(self.nl)], -1)  # (bs, 17*3, h*w)
 
-        # reshape image features (1D field vector) to concatenate with x
+        # reshape one hot feature vector (1D) to concatenate with input image tensor (x)
         device = x[0].device
         x_features_reshaped = []
         for i in range(self.nl):  # per detection scale
-            B, _, H, W = x[i].shape  # different (H, W) shape per detection scale
+            B, _, H, W = x[i].shape  # different (H, W) shape per detection scale (e.g., 24x24, 48x48, 96x96)
             x_features_reshaped.append(x_features.view(B, -1, 1, 1).expand(B, -1, H, W).to(device))  # (B, nc//2, H, W)
 
-        # concatenate x with image features
+        # concatenate x with one hot feature vector
         x_with_features = [torch.concat((xi, x_features_reshaped_i), dim=1) for 
                            (xi, x_features_reshaped_i) in zip(x, x_features_reshaped)]  # (B, C+nc//2, H, W)
 

--- a/ultralytics/utils/loss.py
+++ b/ultralytics/utils/loss.py
@@ -374,158 +374,7 @@ class v8SegmentationLoss(v8DetectionLoss):
         return loss / fg_mask.sum()
 
 
-# class v8PoseLoss(v8DetectionLoss):
-#     """Criterion class for computing training losses."""
-
-#     def __init__(self, model):  # model must be de-paralleled
-#         """Initializes v8PoseLoss with model, sets keypoint variables and declares a keypoint loss instance."""
-#         super().__init__(model)
-#         self.kpt_shape = model.model[-1].kpt_shape
-#         self.bce_pose = nn.BCEWithLogitsLoss()
-#         is_pose = self.kpt_shape == [17, 3]
-#         nkpt = self.kpt_shape[0]  # number of keypoints
-#         sigmas = torch.from_numpy(OKS_SIGMA).to(self.device) if is_pose else torch.ones(nkpt, device=self.device) / nkpt
-#         self.keypoint_loss = KeypointLoss(sigmas=sigmas)
-
-#     def __call__(self, preds, batch):
-#         """Calculate the total loss and detach it."""
-#         loss = torch.zeros(5, device=self.device)  # box, cls, dfl, kpt_location, kpt_visibility
-#         feats, pred_kpts = preds if isinstance(preds[0], list) else preds[1]
-#         pred_distri, pred_scores = torch.cat([xi.view(feats[0].shape[0], self.no, -1) for xi in feats], 2).split(
-#             (self.reg_max * 4, self.nc), 1)
-
-#         # B, grids, ..
-#         pred_scores = pred_scores.permute(0, 2, 1).contiguous()
-#         pred_distri = pred_distri.permute(0, 2, 1).contiguous()
-#         pred_kpts = pred_kpts.permute(0, 2, 1).contiguous()
-
-#         dtype = pred_scores.dtype
-#         imgsz = torch.tensor(feats[0].shape[2:], device=self.device, dtype=dtype) * self.stride[0]  # image size (h,w)
-#         anchor_points, stride_tensor = make_anchors(feats, self.stride, 0.5)
-
-#         # Targets
-#         batch_size = pred_scores.shape[0]
-#         batch_idx = batch['batch_idx'].view(-1, 1)
-#         targets = torch.cat((batch_idx, batch['cls'].view(-1, 1), batch['bboxes']), 1)
-#         targets = self.preprocess(targets.to(self.device), batch_size, scale_tensor=imgsz[[1, 0, 1, 0]])
-#         gt_labels, gt_bboxes = targets.split((1, 4), 2)  # cls, xyxy
-#         mask_gt = gt_bboxes.sum(2, keepdim=True).gt_(0)
-
-#         # Pboxes
-#         pred_bboxes = self.bbox_decode(anchor_points, pred_distri)  # xyxy, (b, h*w, 4)
-#         pred_kpts = self.kpts_decode(anchor_points, pred_kpts.view(batch_size, -1, *self.kpt_shape))  # (b, h*w, 17, 3)
-
-#         _, target_bboxes, target_scores, fg_mask, target_gt_idx = self.assigner(
-#             pred_scores.detach().sigmoid(), (pred_bboxes.detach() * stride_tensor).type(gt_bboxes.dtype),
-#             anchor_points * stride_tensor, gt_labels, gt_bboxes, mask_gt)
-
-#         target_scores_sum = max(target_scores.sum(), 1)
-
-#         # Cls loss
-#         # loss[1] = self.varifocal_loss(pred_scores, target_scores, target_labels) / target_scores_sum  # VFL way
-#         loss[3] = self.bce(pred_scores, target_scores.to(dtype)).sum() / target_scores_sum  # BCE
-
-#         # Bbox loss
-#         if fg_mask.sum():
-#             target_bboxes /= stride_tensor
-#             loss[0], loss[4] = self.bbox_loss(pred_distri, pred_bboxes, anchor_points, target_bboxes, target_scores,
-#                                               target_scores_sum, fg_mask)
-#             keypoints = batch['keypoints'].to(self.device).float().clone()
-#             keypoints[..., 0] *= imgsz[1]
-#             keypoints[..., 1] *= imgsz[0]
-
-#             loss[1], loss[2] = self.calculate_keypoints_loss(fg_mask, target_gt_idx, keypoints, batch_idx,
-#                                                              stride_tensor, target_bboxes, pred_kpts, batch['ignore_kpt'])
-
-#         loss[0] *= self.hyp.box  # box gain
-#         loss[1] *= self.hyp.pose  # pose gain
-#         loss[2] *= self.hyp.kobj  # kobj gain
-#         loss[3] *= self.hyp.cls  # cls gain
-#         loss[4] *= self.hyp.dfl  # dfl gain
-
-#         return loss.sum() * batch_size, loss.detach()  # loss(box, cls, dfl)
-
-#     @staticmethod
-#     def kpts_decode(anchor_points, pred_kpts):
-#         """Decodes predicted keypoints to image coordinates."""
-#         y = pred_kpts.clone()
-#         y[..., :2] *= 2.0
-#         y[..., 0] += anchor_points[:, [0]] - 0.5
-#         y[..., 1] += anchor_points[:, [1]] - 0.5
-#         return y
-
-#     def calculate_keypoints_loss(self, masks, target_gt_idx, keypoints, batch_idx, stride_tensor, target_bboxes,
-#                                  pred_kpts, ignore_kpt):
-#         """
-#         Calculate the keypoints loss for the model.
-
-#         This function calculates the keypoints loss and keypoints object loss for a given batch. The keypoints loss is
-#         based on the difference between the predicted keypoints and ground truth keypoints. The keypoints object loss is
-#         a binary classification loss that classifies whether a keypoint is present or not.
-
-#         Args:
-#             masks (torch.Tensor): Binary mask tensor indicating object presence, shape (BS, N_anchors).
-#             target_gt_idx (torch.Tensor): Index tensor mapping anchors to ground truth objects, shape (BS, N_anchors).
-#             keypoints (torch.Tensor): Ground truth keypoints, shape (N_kpts_in_batch, N_kpts_per_object, kpts_dim).
-#             batch_idx (torch.Tensor): Batch index tensor for keypoints, shape (N_kpts_in_batch, 1).
-#             stride_tensor (torch.Tensor): Stride tensor for anchors, shape (N_anchors, 1).
-#             target_bboxes (torch.Tensor): Ground truth boxes in (x1, y1, x2, y2) format, shape (BS, N_anchors, 4).
-#             pred_kpts (torch.Tensor): Predicted keypoints, shape (BS, N_anchors, N_kpts_per_object, kpts_dim).
-
-#         Returns:
-#             (tuple): Returns a tuple containing:
-#                 - kpts_loss (torch.Tensor): The keypoints loss.
-#                 - kpts_obj_loss (torch.Tensor): The keypoints object loss.
-#         """
-#         batch_idx = batch_idx.flatten()
-#         batch_size = len(masks)
-
-#         # Find the maximum number of keypoints in a single image
-#         max_kpts = torch.unique(batch_idx, return_counts=True)[1].max()
-
-#         # Create a tensor to hold batched keypoints
-#         batched_keypoints = torch.zeros((batch_size, max_kpts, keypoints.shape[1], keypoints.shape[2]),
-#                                         device=keypoints.device)
-
-#         # TODO: any idea how to vectorize this?
-#         # Fill batched_keypoints with keypoints based on batch_idx
-#         for i in range(batch_size):
-#             keypoints_i = keypoints[batch_idx == i]
-#             batched_keypoints[i, :keypoints_i.shape[0]] = keypoints_i
-
-#         # Expand dimensions of target_gt_idx to match the shape of batched_keypoints
-#         target_gt_idx_expanded = target_gt_idx.unsqueeze(-1).unsqueeze(-1)
-
-#         # Use target_gt_idx_expanded to select keypoints from batched_keypoints
-#         selected_keypoints = batched_keypoints.gather(
-#             1, target_gt_idx_expanded.expand(-1, -1, keypoints.shape[1], keypoints.shape[2]))
-
-#         # Divide coordinates by stride
-#         selected_keypoints /= stride_tensor.view(1, -1, 1, 1)
-
-#         kpts_loss = 0
-#         kpts_obj_loss = 0
-
-#         for i in range(batch_size):
-#             if ignore_kpt[i]:
-#                 # We should ignore the keypoints for this image
-#                 # We replace gt keypoints with pred keypoints so distance is 0. kpts_loss will be 0
-#                 selected_keypoints[i] = pred_kpts[i]
-
-#         if masks.any():
-#             gt_kpt = selected_keypoints[masks]
-#             area = xyxy2xywh(target_bboxes[masks])[:, 2:].prod(1, keepdim=True)
-#             pred_kpt = pred_kpts[masks]
-#             kpt_mask = gt_kpt[..., 2] != 0 if gt_kpt.shape[-1] == 3 else torch.full_like(gt_kpt[..., 0], True)
-#             kpts_loss = self.keypoint_loss(pred_kpt, gt_kpt, kpt_mask, area)  # pose loss
-
-#             if pred_kpt.shape[-1] == 3:
-#                 kpts_obj_loss = self.bce_pose(pred_kpt[..., 2], kpt_mask.float())  # keypoint obj loss
-
-#         return kpts_loss, kpts_obj_loss
-
-
-class v8PoseLoss(v8DetectionLoss):  # experimental
+class v8PoseLoss(v8DetectionLoss):
     """Criterion class for computing training losses."""
 
     def __init__(self, model):  # model must be de-paralleled
@@ -559,8 +408,8 @@ class v8PoseLoss(v8DetectionLoss):  # experimental
         batch_idx = batch['batch_idx'].view(-1, 1)
         targets = torch.cat((batch_idx, batch['cls'].view(-1, 1), batch['bboxes']), 1)
         targets = self.preprocess(targets.to(self.device), batch_size, scale_tensor=imgsz[[1, 0, 1, 0]])
-        gt_labels, gt_bboxes = targets.split((1, 4), 2)  # cls (B, n_anchors, 1), xyxy (B, n_anchors, 4)
-        mask_gt = gt_bboxes.sum(2, keepdim=True).gt_(0)  # boolean vector indicating exitance of gt bbox (B, n_anchors, 1)
+        gt_labels, gt_bboxes = targets.split((1, 4), 2)  # cls, xyxy
+        mask_gt = gt_bboxes.sum(2, keepdim=True).gt_(0)
 
         # Pboxes
         pred_bboxes = self.bbox_decode(anchor_points, pred_distri)  # xyxy, (b, h*w, 4)
@@ -573,12 +422,8 @@ class v8PoseLoss(v8DetectionLoss):  # experimental
         target_scores_sum = max(target_scores.sum(), 1)
 
         # Cls loss
-        # find index of image that has no gt_labes (nothing detected) and make bce loss for that index 0
-        loss[3] = torch.zeros((), device=self.device, dtype=dtype, requires_grad=True) 
-        for i, mask in enumerate(mask_gt):  # iterate over batch dim
-            cls_loss = self.bce(pred_scores[i], target_scores[i].to(dtype)).sum()
-            loss[3] += cls_loss if mask.sum() > 0 else cls_loss * 0.0  # don't update model if no gt bbox
-        loss[3] /= target_scores_sum
+        # loss[1] = self.varifocal_loss(pred_scores, target_scores, target_labels) / target_scores_sum  # VFL way
+        loss[3] = self.bce(pred_scores, target_scores.to(dtype)).sum() / target_scores_sum  # BCE
 
         # Bbox loss
         if fg_mask.sum():
@@ -678,6 +523,76 @@ class v8PoseLoss(v8DetectionLoss):  # experimental
                 kpts_obj_loss = self.bce_pose(pred_kpt[..., 2], kpt_mask.float())  # keypoint obj loss
 
         return kpts_loss, kpts_obj_loss
+
+
+class v8PoseTunableHeadLoss(v8PoseLoss):
+    """Criterion class for computing training losses."""
+
+    def __init__(self, model):  # model must be de-paralleled
+        """Initializes v8PoseTunableHeadLoss with model, sets keypoint variables and declares a keypoint loss instance."""
+        super().__init__(model)
+
+    def __call__(self, preds, batch):
+        """Calculate the total loss and detach it."""
+        loss = torch.zeros(5, device=self.device)  # box, cls, dfl, kpt_location, kpt_visibility
+        feats, pred_kpts = preds if isinstance(preds[0], list) else preds[1]
+        pred_distri, pred_scores = torch.cat([xi.view(feats[0].shape[0], self.no, -1) for xi in feats], 2).split(
+            (self.reg_max * 4, self.nc), 1)
+
+        # B, grids, ..
+        pred_scores = pred_scores.permute(0, 2, 1).contiguous()
+        pred_distri = pred_distri.permute(0, 2, 1).contiguous()
+        pred_kpts = pred_kpts.permute(0, 2, 1).contiguous()
+
+        dtype = pred_scores.dtype
+        imgsz = torch.tensor(feats[0].shape[2:], device=self.device, dtype=dtype) * self.stride[0]  # image size (h,w)
+        anchor_points, stride_tensor = make_anchors(feats, self.stride, 0.5)
+
+        # Targets
+        batch_size = pred_scores.shape[0]
+        batch_idx = batch['batch_idx'].view(-1, 1)
+        targets = torch.cat((batch_idx, batch['cls'].view(-1, 1), batch['bboxes']), 1)
+        targets = self.preprocess(targets.to(self.device), batch_size, scale_tensor=imgsz[[1, 0, 1, 0]])
+        gt_labels, gt_bboxes = targets.split((1, 4), 2)  # cls (B, n_anchors, 1), xyxy (B, n_anchors, 4)
+        mask_gt = gt_bboxes.sum(2, keepdim=True).gt_(0)  # boolean vector indicating exitance of gt bbox (B, n_anchors, 1)
+
+        # Pboxes
+        pred_bboxes = self.bbox_decode(anchor_points, pred_distri)  # xyxy, (b, h*w, 4)
+        pred_kpts = self.kpts_decode(anchor_points, pred_kpts.view(batch_size, -1, *self.kpt_shape))  # (b, h*w, 17, 3)
+
+        _, target_bboxes, target_scores, fg_mask, target_gt_idx = self.assigner(
+            pred_scores.detach().sigmoid(), (pred_bboxes.detach() * stride_tensor).type(gt_bboxes.dtype),
+            anchor_points * stride_tensor, gt_labels, gt_bboxes, mask_gt)
+
+        target_scores_sum = max(target_scores.sum(), 1)
+
+        # Cls loss
+        # find index of image that has no gt_labes (nothing detected) and make bce loss for that index 0
+        loss[3] = torch.zeros((), device=self.device, dtype=dtype, requires_grad=True) 
+        for i, mask in enumerate(mask_gt):  # iterate over batch dim
+            cls_loss = self.bce(pred_scores[i], target_scores[i].to(dtype)).sum()
+            loss[3] += cls_loss if mask.sum() > 0 else cls_loss * 0.0  # don't update model if no gt bbox
+        loss[3] /= target_scores_sum
+
+        # Bbox loss
+        if fg_mask.sum():
+            target_bboxes /= stride_tensor
+            loss[0], loss[4] = self.bbox_loss(pred_distri, pred_bboxes, anchor_points, target_bboxes, target_scores,
+                                              target_scores_sum, fg_mask)
+            keypoints = batch['keypoints'].to(self.device).float().clone()
+            keypoints[..., 0] *= imgsz[1]
+            keypoints[..., 1] *= imgsz[0]
+
+            loss[1], loss[2] = self.calculate_keypoints_loss(fg_mask, target_gt_idx, keypoints, batch_idx,
+                                                             stride_tensor, target_bboxes, pred_kpts, batch['ignore_kpt'])
+
+        loss[0] *= self.hyp.box  # box gain
+        loss[1] *= self.hyp.pose  # pose gain
+        loss[2] *= self.hyp.kobj  # kobj gain
+        loss[3] *= self.hyp.cls  # cls gain
+        loss[4] *= self.hyp.dfl  # dfl gain
+
+        return loss.sum() * batch_size, loss.detach()  # loss(box, cls, dfl)
     
 
 class v8PoseContrastiveLoss(v8PoseLoss):

--- a/ultralytics/utils/loss.py
+++ b/ultralytics/utils/loss.py
@@ -374,7 +374,158 @@ class v8SegmentationLoss(v8DetectionLoss):
         return loss / fg_mask.sum()
 
 
-class v8PoseLoss(v8DetectionLoss):
+# class v8PoseLoss(v8DetectionLoss):
+#     """Criterion class for computing training losses."""
+
+#     def __init__(self, model):  # model must be de-paralleled
+#         """Initializes v8PoseLoss with model, sets keypoint variables and declares a keypoint loss instance."""
+#         super().__init__(model)
+#         self.kpt_shape = model.model[-1].kpt_shape
+#         self.bce_pose = nn.BCEWithLogitsLoss()
+#         is_pose = self.kpt_shape == [17, 3]
+#         nkpt = self.kpt_shape[0]  # number of keypoints
+#         sigmas = torch.from_numpy(OKS_SIGMA).to(self.device) if is_pose else torch.ones(nkpt, device=self.device) / nkpt
+#         self.keypoint_loss = KeypointLoss(sigmas=sigmas)
+
+#     def __call__(self, preds, batch):
+#         """Calculate the total loss and detach it."""
+#         loss = torch.zeros(5, device=self.device)  # box, cls, dfl, kpt_location, kpt_visibility
+#         feats, pred_kpts = preds if isinstance(preds[0], list) else preds[1]
+#         pred_distri, pred_scores = torch.cat([xi.view(feats[0].shape[0], self.no, -1) for xi in feats], 2).split(
+#             (self.reg_max * 4, self.nc), 1)
+
+#         # B, grids, ..
+#         pred_scores = pred_scores.permute(0, 2, 1).contiguous()
+#         pred_distri = pred_distri.permute(0, 2, 1).contiguous()
+#         pred_kpts = pred_kpts.permute(0, 2, 1).contiguous()
+
+#         dtype = pred_scores.dtype
+#         imgsz = torch.tensor(feats[0].shape[2:], device=self.device, dtype=dtype) * self.stride[0]  # image size (h,w)
+#         anchor_points, stride_tensor = make_anchors(feats, self.stride, 0.5)
+
+#         # Targets
+#         batch_size = pred_scores.shape[0]
+#         batch_idx = batch['batch_idx'].view(-1, 1)
+#         targets = torch.cat((batch_idx, batch['cls'].view(-1, 1), batch['bboxes']), 1)
+#         targets = self.preprocess(targets.to(self.device), batch_size, scale_tensor=imgsz[[1, 0, 1, 0]])
+#         gt_labels, gt_bboxes = targets.split((1, 4), 2)  # cls, xyxy
+#         mask_gt = gt_bboxes.sum(2, keepdim=True).gt_(0)
+
+#         # Pboxes
+#         pred_bboxes = self.bbox_decode(anchor_points, pred_distri)  # xyxy, (b, h*w, 4)
+#         pred_kpts = self.kpts_decode(anchor_points, pred_kpts.view(batch_size, -1, *self.kpt_shape))  # (b, h*w, 17, 3)
+
+#         _, target_bboxes, target_scores, fg_mask, target_gt_idx = self.assigner(
+#             pred_scores.detach().sigmoid(), (pred_bboxes.detach() * stride_tensor).type(gt_bboxes.dtype),
+#             anchor_points * stride_tensor, gt_labels, gt_bboxes, mask_gt)
+
+#         target_scores_sum = max(target_scores.sum(), 1)
+
+#         # Cls loss
+#         # loss[1] = self.varifocal_loss(pred_scores, target_scores, target_labels) / target_scores_sum  # VFL way
+#         loss[3] = self.bce(pred_scores, target_scores.to(dtype)).sum() / target_scores_sum  # BCE
+
+#         # Bbox loss
+#         if fg_mask.sum():
+#             target_bboxes /= stride_tensor
+#             loss[0], loss[4] = self.bbox_loss(pred_distri, pred_bboxes, anchor_points, target_bboxes, target_scores,
+#                                               target_scores_sum, fg_mask)
+#             keypoints = batch['keypoints'].to(self.device).float().clone()
+#             keypoints[..., 0] *= imgsz[1]
+#             keypoints[..., 1] *= imgsz[0]
+
+#             loss[1], loss[2] = self.calculate_keypoints_loss(fg_mask, target_gt_idx, keypoints, batch_idx,
+#                                                              stride_tensor, target_bboxes, pred_kpts, batch['ignore_kpt'])
+
+#         loss[0] *= self.hyp.box  # box gain
+#         loss[1] *= self.hyp.pose  # pose gain
+#         loss[2] *= self.hyp.kobj  # kobj gain
+#         loss[3] *= self.hyp.cls  # cls gain
+#         loss[4] *= self.hyp.dfl  # dfl gain
+
+#         return loss.sum() * batch_size, loss.detach()  # loss(box, cls, dfl)
+
+#     @staticmethod
+#     def kpts_decode(anchor_points, pred_kpts):
+#         """Decodes predicted keypoints to image coordinates."""
+#         y = pred_kpts.clone()
+#         y[..., :2] *= 2.0
+#         y[..., 0] += anchor_points[:, [0]] - 0.5
+#         y[..., 1] += anchor_points[:, [1]] - 0.5
+#         return y
+
+#     def calculate_keypoints_loss(self, masks, target_gt_idx, keypoints, batch_idx, stride_tensor, target_bboxes,
+#                                  pred_kpts, ignore_kpt):
+#         """
+#         Calculate the keypoints loss for the model.
+
+#         This function calculates the keypoints loss and keypoints object loss for a given batch. The keypoints loss is
+#         based on the difference between the predicted keypoints and ground truth keypoints. The keypoints object loss is
+#         a binary classification loss that classifies whether a keypoint is present or not.
+
+#         Args:
+#             masks (torch.Tensor): Binary mask tensor indicating object presence, shape (BS, N_anchors).
+#             target_gt_idx (torch.Tensor): Index tensor mapping anchors to ground truth objects, shape (BS, N_anchors).
+#             keypoints (torch.Tensor): Ground truth keypoints, shape (N_kpts_in_batch, N_kpts_per_object, kpts_dim).
+#             batch_idx (torch.Tensor): Batch index tensor for keypoints, shape (N_kpts_in_batch, 1).
+#             stride_tensor (torch.Tensor): Stride tensor for anchors, shape (N_anchors, 1).
+#             target_bboxes (torch.Tensor): Ground truth boxes in (x1, y1, x2, y2) format, shape (BS, N_anchors, 4).
+#             pred_kpts (torch.Tensor): Predicted keypoints, shape (BS, N_anchors, N_kpts_per_object, kpts_dim).
+
+#         Returns:
+#             (tuple): Returns a tuple containing:
+#                 - kpts_loss (torch.Tensor): The keypoints loss.
+#                 - kpts_obj_loss (torch.Tensor): The keypoints object loss.
+#         """
+#         batch_idx = batch_idx.flatten()
+#         batch_size = len(masks)
+
+#         # Find the maximum number of keypoints in a single image
+#         max_kpts = torch.unique(batch_idx, return_counts=True)[1].max()
+
+#         # Create a tensor to hold batched keypoints
+#         batched_keypoints = torch.zeros((batch_size, max_kpts, keypoints.shape[1], keypoints.shape[2]),
+#                                         device=keypoints.device)
+
+#         # TODO: any idea how to vectorize this?
+#         # Fill batched_keypoints with keypoints based on batch_idx
+#         for i in range(batch_size):
+#             keypoints_i = keypoints[batch_idx == i]
+#             batched_keypoints[i, :keypoints_i.shape[0]] = keypoints_i
+
+#         # Expand dimensions of target_gt_idx to match the shape of batched_keypoints
+#         target_gt_idx_expanded = target_gt_idx.unsqueeze(-1).unsqueeze(-1)
+
+#         # Use target_gt_idx_expanded to select keypoints from batched_keypoints
+#         selected_keypoints = batched_keypoints.gather(
+#             1, target_gt_idx_expanded.expand(-1, -1, keypoints.shape[1], keypoints.shape[2]))
+
+#         # Divide coordinates by stride
+#         selected_keypoints /= stride_tensor.view(1, -1, 1, 1)
+
+#         kpts_loss = 0
+#         kpts_obj_loss = 0
+
+#         for i in range(batch_size):
+#             if ignore_kpt[i]:
+#                 # We should ignore the keypoints for this image
+#                 # We replace gt keypoints with pred keypoints so distance is 0. kpts_loss will be 0
+#                 selected_keypoints[i] = pred_kpts[i]
+
+#         if masks.any():
+#             gt_kpt = selected_keypoints[masks]
+#             area = xyxy2xywh(target_bboxes[masks])[:, 2:].prod(1, keepdim=True)
+#             pred_kpt = pred_kpts[masks]
+#             kpt_mask = gt_kpt[..., 2] != 0 if gt_kpt.shape[-1] == 3 else torch.full_like(gt_kpt[..., 0], True)
+#             kpts_loss = self.keypoint_loss(pred_kpt, gt_kpt, kpt_mask, area)  # pose loss
+
+#             if pred_kpt.shape[-1] == 3:
+#                 kpts_obj_loss = self.bce_pose(pred_kpt[..., 2], kpt_mask.float())  # keypoint obj loss
+
+#         return kpts_loss, kpts_obj_loss
+
+
+class v8PoseLoss(v8DetectionLoss):  # experimental
     """Criterion class for computing training losses."""
 
     def __init__(self, model):  # model must be de-paralleled
@@ -408,8 +559,8 @@ class v8PoseLoss(v8DetectionLoss):
         batch_idx = batch['batch_idx'].view(-1, 1)
         targets = torch.cat((batch_idx, batch['cls'].view(-1, 1), batch['bboxes']), 1)
         targets = self.preprocess(targets.to(self.device), batch_size, scale_tensor=imgsz[[1, 0, 1, 0]])
-        gt_labels, gt_bboxes = targets.split((1, 4), 2)  # cls, xyxy
-        mask_gt = gt_bboxes.sum(2, keepdim=True).gt_(0)
+        gt_labels, gt_bboxes = targets.split((1, 4), 2)  # cls (B, n_anchors, 1), xyxy (B, n_anchors, 4)
+        mask_gt = gt_bboxes.sum(2, keepdim=True).gt_(0)  # boolean vector indicating exitance of gt bbox (B, n_anchors, 1)
 
         # Pboxes
         pred_bboxes = self.bbox_decode(anchor_points, pred_distri)  # xyxy, (b, h*w, 4)
@@ -422,8 +573,12 @@ class v8PoseLoss(v8DetectionLoss):
         target_scores_sum = max(target_scores.sum(), 1)
 
         # Cls loss
-        # loss[1] = self.varifocal_loss(pred_scores, target_scores, target_labels) / target_scores_sum  # VFL way
-        loss[3] = self.bce(pred_scores, target_scores.to(dtype)).sum() / target_scores_sum  # BCE
+        # find index of image that has no gt_labes (nothing detected) and make bce loss for that index 0
+        loss[3] = torch.zeros((), device=self.device, dtype=dtype, requires_grad=True) 
+        for i, mask in enumerate(mask_gt):  # iterate over batch dim
+            cls_loss = self.bce(pred_scores[i], target_scores[i].to(dtype)).sum()
+            loss[3] += cls_loss if mask.sum() > 0 else cls_loss * 0.0  # don't update model if no gt bbox
+        loss[3] /= target_scores_sum
 
         # Bbox loss
         if fg_mask.sum():
@@ -523,7 +678,7 @@ class v8PoseLoss(v8DetectionLoss):
                 kpts_obj_loss = self.bce_pose(pred_kpt[..., 2], kpt_mask.float())  # keypoint obj loss
 
         return kpts_loss, kpts_obj_loss
-
+    
 
 class v8PoseContrastiveLoss(v8PoseLoss):
     """Criterion class for computing training losses."""

--- a/ultralytics/utils/plotting.py
+++ b/ultralytics/utils/plotting.py
@@ -666,7 +666,7 @@ def feature_visualization(x, module_type, stage, n=32, save_dir=Path('runs/detec
         n (int, optional): Maximum number of feature maps to plot. Defaults to 32.
         save_dir (Path, optional): Directory to save results. Defaults to Path('runs/detect/exp').
     """
-    for m in ['Detect', 'DetectContrastive', 'DetectMultiClsHeads', 'Pose', 'PoseContrastive', 'PoseMultiClsHeads', 'Segment']:
+    for m in ['Detect', 'DetectContrastive', 'DetectMultiClsHeads', 'DetectTunableHead', 'Pose', 'PoseContrastive', 'PoseMultiClsHeads', 'PoseTunableHead', 'Segment']:
         if m in module_type:
             return
     batch, channels, height, width = x.shape  # batch, channels, height, width


### PR DESCRIPTION
## Context
This code implements a tunable (switchable) classification head for a pose model.
The task for training a tunable head is named "pose-trainablehead".
It has new classes defined for task model, head, loss criterion, and trainer (e.g., "PoseTrainableHeadModel" for task model class).
This model passes in a one-hot vector of features (index of image source as of now) as the extra input argument to the classification head of the model.

![image](https://github.com/user-attachments/assets/1300cd7e-4ec3-4a25-b86d-0948a1013cb1)

![image](https://github.com/user-attachments/assets/0589f91b-5370-4738-97ae-d5906cc254f6)

## Test
1. Create a docker container for model training inside `~/verdant/dev/src/python/trainers/yolo8`.
- `./start.sh {data dir} {runs dir where checkpoints and ONNX files will be saved} shell -u {local ultralytics dir} -c {name of docker container to create}`
Example:
`./start.sh ~/data/lettuce_brassica_endive_tomato_artichoke_rose_011525/ ~/data/runs pose-tunablehead shell -u ~/verdant/ultralytics -c teset_031025`
2. Run `python simple_training.py` inside the docker container.
3. Once the training is complete and the ONNX format of the model is saved (e.g., "best.onnx"), double check whether it allows the user to pass in a one-hot vector as the 2nd input argument.
- Notes: The one-hot vector input must match the number of training sources (N). For example, with 5 sources, to indicate source index 2 (index starts from 0), use [0, 0, 1, 0, 0].