### PR TITLE
Keep lr multiiplier for lr scheduler as a positive constant less than 1

### DIFF
--- a/training_utils/simple_training.py
+++ b/training_utils/simple_training.py
@@ -42,7 +42,7 @@ if __name__ == "__main__":
         data="verdant.yaml",
         optimizer='SGD',
         lr0=args.learning_rate,
-        lrf=args.learning_rate,
+        lrf=0.01,
         epochs=300,
         flipud=0.5,
         fliplr=0.5,


### PR DESCRIPTION
This minor code change keeps the learning rate multiplier for the linear learning rate scheduler as a positive constant less than 1 so that the learning rate always decreases over training epochs.

## Test
`python simple_training.py`
OR
`python simple_training.py -r 0.01`