### PR TITLE
Export all model checkpoints

### DIFF
--- a/training_utils/export.py
+++ b/training_utils/export.py
@@ -5,41 +5,33 @@ import os
 import argparse
 
 
-def Export(checkpoint_dir):
-    if not os.path.exists(checkpoint_dir):
-        print(f"[ERROR] : Model {checkpoint_dir} does not exists")
+def Export(checkpoint_file_path):
+    if os.path.exists(checkpoint_file_path):
+        model = GiveModel(checkpoint_file_path)
+    else:
+        print(f"[ERROR] : Model {checkpoint_file_path} does not exists")
         exit(1)
 
-    checkpoint_files = ["best.pt", "last.pt"]
+    prefix = os.path.splitext(os.path.basename(checkpoint_file_path))[0]
 
-    for file in checkpoint_files:
-        checkpoint_file_path = os.path.join(checkpoint_dir, file)
-        if not os.path.exists(checkpoint_file_path):
-            print(f"[ERROR] : Model {checkpoint_file_path} does not exists")
-            continue
+    base_path, _ = os.path.split(checkpoint_file_path)
+    path = model.export(format="onnx", imgsz=[2144, 768], opset=12)
+    os.system(f"mv {path} {base_path}/{prefix}_full_height.onnx")
 
-        prefix = file.split(".")[0]  # "best" or "last"
+    path = model.export(format="onnx", imgsz=[2144, 4096], opset=12)
+    os.system(f"mv {path} {base_path}/{prefix}_full_frame.onnx")
 
-        model = GiveModel(checkpoint_file_path)
-
-        base_path = checkpoint_dir
-        path = model.export(format="onnx", imgsz=[2144, 768], opset=12)
-        os.system(f"mv {path} {base_path}/{prefix}_full_height.onnx")
-
-        path = model.export(format="onnx", imgsz=[2144, 4096], opset=12)
-        os.system(f"mv {path} {base_path}/{prefix}_full_frame.onnx")
-
-        path = model.export(format="onnx", imgsz=[768, 768], opset=12)
+    path = model.export(format="onnx", imgsz=[768, 768], opset=12)
 
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="Export the model")
     parser.add_argument(
         "-m",
-        "--checkpoint_dir",
+        "--checkpoint_path",
         type=str,
         required=True,
-        help="Path to the checkpoint directory where the model weight is. This model will be exported")
+        help="Path to the model weight checkpoint; This model will be exported")
 
     args = parser.parse_args()
-    Export(args.checkpoint_dir)
+    Export(args.checkpoint_path)

--- a/training_utils/simple_training.py
+++ b/training_utils/simple_training.py
@@ -22,9 +22,14 @@ if __name__ == "__main__":
     parser.add_argument("-e", "--epochs", type=int, default=200, help="Number of epochs for training")
     parser.add_argument("-p", "--patience", type=int, default=50, help="Number of epochs triggering early stopping when no improvement")
     parser.add_argument("-s", "--batch-size", type=int, default=128, help="Batch size for training")
+    parser.add_argument("-w", "--model-ckpt", type=str, default="best.pt", help="model weight checkpoint (.pt) file to convert to ONNX; Options: best.pt & last.pt (optional, default: best.pt)")
     parser.add_argument("-b", "--disable-wandb", action="store_true", help="Disable wandb logging")
 
     args = parser.parse_args()
+
+    if args.model_ckpt not in ["best.pt", "last.pt"]:
+        print(f"[ERROR] : model-ckpt should be either best.pt or last.pt")
+        exit(1)
 
     print(f"Model weights initialized from: {args.load if args.load else 'scratch'}")
     print(f"Learning rate: {args.learning_rate}, Epochs: {args.epochs}, Patience: {args.patience}, Batch size: {args.batch_size}")
@@ -63,4 +68,4 @@ if __name__ == "__main__":
     )
 
     latest_weights_dir = GetLatestWeightsDir()
-    Export(f"{latest_weights_dir}/best.pt")  # To export the model to onnx format
+    Export(f"{latest_weights_dir}/{args.model_ckpt}")  # To export the model to onnx format

--- a/training_utils/simple_training.py
+++ b/training_utils/simple_training.py
@@ -64,6 +64,5 @@ if __name__ == "__main__":
 
     print("Training completed. Exporting the model by converting checkpoints to ONNX format...")
     latest_weights_dir = GetLatestWeightsDir()
-    checkpoint_files = ["best.pt", "last.pt"]
-    for file in checkpoint_files:
-        Export(f"{latest_weights_dir}/{file}")  # export model checkpoints to onnx format
+    Export(f"{latest_weights_dir}/best.pt")
+    Export(f"{latest_weights_dir}/last.pt")

--- a/training_utils/simple_training.py
+++ b/training_utils/simple_training.py
@@ -22,14 +22,9 @@ if __name__ == "__main__":
     parser.add_argument("-e", "--epochs", type=int, default=200, help="Number of epochs for training")
     parser.add_argument("-p", "--patience", type=int, default=50, help="Number of epochs triggering early stopping when no improvement")
     parser.add_argument("-s", "--batch-size", type=int, default=128, help="Batch size for training")
-    parser.add_argument("-w", "--model-ckpt", type=str, default="best.pt", help="model weight checkpoint (.pt) file to convert to ONNX; Options: best.pt & last.pt (optional, default: best.pt)")
     parser.add_argument("-b", "--disable-wandb", action="store_true", help="Disable wandb logging")
 
     args = parser.parse_args()
-
-    if args.model_ckpt not in ["best.pt", "last.pt"]:
-        print(f"[ERROR] : model-ckpt should be either best.pt or last.pt")
-        exit(1)
 
     print(f"Model weights initialized from: {args.load if args.load else 'scratch'}")
     print(f"Learning rate: {args.learning_rate}, Epochs: {args.epochs}, Patience: {args.patience}, Batch size: {args.batch_size}")
@@ -67,5 +62,6 @@ if __name__ == "__main__":
         patience=args.patience,
     )
 
+    print("Training completed. Exporting the model by converting checkpoints to ONNX format...")
     latest_weights_dir = GetLatestWeightsDir()
-    Export(f"{latest_weights_dir}/{args.model_ckpt}")  # To export the model to onnx format
+    Export(latest_weights_dir)  # export model checkpoints to onnx format

--- a/training_utils/simple_training.py
+++ b/training_utils/simple_training.py
@@ -64,4 +64,6 @@ if __name__ == "__main__":
 
     print("Training completed. Exporting the model by converting checkpoints to ONNX format...")
     latest_weights_dir = GetLatestWeightsDir()
-    Export(latest_weights_dir)  # export model checkpoints to onnx format
+    checkpoint_files = ["best.pt", "last.pt"]
+    for file in checkpoint_files:
+        Export(f"{latest_weights_dir}/{file}")  # export model checkpoints to onnx format


### PR DESCRIPTION
This code change lets the simple training Python script export both best and last *.pt checkpoints to the ONNX format after training is done.
- Each of the two checkpoint files (best.pt, last.pt) will be converted to `<checkpoint_name>.onnx`, `<checkpoint_name_full_frame>.onnx`, and `<checkpoint_name_full_height>.onnx`

Previously, only best.pt was exported (or only last.pt if best.pt didn't exist).
<img width="1162" height="37" alt="image" src="https://github.com/user-attachments/assets/aa365ab5-6e92-4f00-b0a8-000156d7b945" />

The new code change will export both best.pt and last.pt.
<img width="1161" height="38" alt="image" src="https://github.com/user-attachments/assets/fe79fe13-29e4-45dc-9199-d87e989773b1" />

